### PR TITLE
Inject CorountineDispatchers into FirebaseAuthService and FirebaseMapsService

### DIFF
--- a/core/src/main/kotlin/com/omricat/maplibrarian/utils/DispatcherProvider.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/utils/DispatcherProvider.kt
@@ -1,0 +1,19 @@
+package com.omricat.maplibrarian.utils
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+public interface DispatcherProvider {
+
+    public val default: CoroutineDispatcher
+    public val io: CoroutineDispatcher
+    public val main: CoroutineDispatcher
+    public val unconfined: CoroutineDispatcher
+
+    public companion object Default : DispatcherProvider {
+        override val default: CoroutineDispatcher get() = Dispatchers.Default
+        override val io: CoroutineDispatcher get() = Dispatchers.IO
+        override val main: CoroutineDispatcher get() = Dispatchers.Main
+        override val unconfined: CoroutineDispatcher get() = Dispatchers.Unconfined
+    }
+}


### PR DESCRIPTION
Introduce runSuspendCatching which allows coroutines started within it to be cancelled if the parent scope is cancelled