### PR TITLE
Restructure db and lockdown firestore.rules

### DIFF
--- a/app/src/main/kotlin/com/omricat/maplibrarian/maplist/FirebaseMapsService.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/maplist/FirebaseMapsService.kt
@@ -27,8 +27,7 @@ class FirebaseMapsService(
     override suspend fun mapsListForUser(user: User): Result<List<DbMapModel>, MapsServiceError> =
         withContext(dispatchers.io) {
             runSuspendCatching {
-                db.mapsCollection()
-                    .whereEqualTo("userId", user.id.id)
+                db.mapsCollection(user)
                     .get()
                     .await()
             }
@@ -48,7 +47,7 @@ class FirebaseMapsService(
         }
         return withContext(dispatchers.io) {
             runSuspendCatching {
-                db.mapsCollection()
+                db.mapsCollection(user)
                     .add(newMap.serialized())
                     .await()
             }
@@ -56,7 +55,10 @@ class FirebaseMapsService(
             .map { ref -> DbMapModel(MapId(ref.id), newMap) }
     }
 
-    private fun FirebaseFirestore.mapsCollection() = collection("maps")
+    private fun FirebaseFirestore.mapsCollection(user: User) =
+        collection("users")
+            .document(user.id.toString())
+            .collection("maps")
 }
 
 internal fun DocumentSnapshot.parseMapModel() =

--- a/firestore.rules
+++ b/firestore.rules
@@ -2,11 +2,21 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    match /{document=**} {
-    	// This rule allows write access to any authenticated user before October 2021
-	    allow write: if request.auth != null && request.time < timestamp.date(2021, 10, 1);
-	    // Allow reading for any authenticated user
-	    allow read: if request.auth != null;
+    function isSignedInUser(request, userId) {
+    	return request.auth != null && request.auth.uid == userId
+    }
+
+    match /users/{userId}/maps/{document=**} {
+    	// This rule allows write access to anything in the maps collection only for the logged in user
+	    allow write: if isSignedInUser(request, userId);
+	    // Allow reading maps collection for authenticated user
+	    allow read: if isSignedInUser(request, userId);
+    }
+
+    match /users/{userId} {
+        allow create: if isSignedInUser(request, userId);
+        allow update: if isSignedInUser(request, userId);
+        allow read: if isSignedInUser(request, userId);
     }
   }
 }

--- a/scripts/add-data-to-emulator
+++ b/scripts/add-data-to-emulator
@@ -5,6 +5,7 @@ projectroot="$(git rev-parse --show-toplevel)"
 datafile="$projectroot/resources/sample-titles.txt"
 defaultuserId="XbmeeiiyihVjM5aBtVT0frNiGall"
 fuego="$projectroot/scripts/fuego-emulator-wrapper"
+"$fuego" set "users/$defaultuserId" "{\"exists\": true }"
 head -n 10 "$datafile" | while IFS='' read -r LINE || [ -n "${LINE}" ]; do
-    "$fuego" add "maps" "{ \"userId\" : \"${defaultuserId}\", \"title\" : \"${LINE}\" }"
+    "$fuego" add "users/$defaultuserId/maps" "{ \"title\" : \"${LINE}\" }"
 done


### PR DESCRIPTION
- Restructure db, keeping maps in a collection under each user
- Lock down firestore.rules quite a bit. Closes #26.

