### PR TITLE
Fix incorrect firebase call

### DIFF
--- a/app/src/main/kotlin/com/omricat/maplibrarian/DefaultDiContainer.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/DefaultDiContainer.kt
@@ -6,6 +6,7 @@ import com.omricat.maplibrarian.auth.AuthWorkflow
 import com.omricat.maplibrarian.auth.SignUpWorkflow
 import com.omricat.maplibrarian.chartlist.ActualChartsWorkflow
 import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow
+import com.omricat.maplibrarian.chartlist.ChartDetailsWorkflow
 import com.omricat.maplibrarian.chartlist.ChartsWorkflow
 import com.omricat.maplibrarian.chartlist.MapListViewRegistry
 import com.omricat.maplibrarian.root.AuthorizedScreenLayoutRunner
@@ -24,10 +25,13 @@ abstract class DefaultDiContainer : DiContainer {
             )
         }
 
+        override val addNewChartWorkflow by lazy { AddNewChartWorkflow(chartsService) }
+
         override val charts: ChartsWorkflow by lazy {
             ActualChartsWorkflow(
                 chartsService,
-                AddNewChartWorkflow(chartsService)
+                addNewChartWorkflow,
+                ChartDetailsWorkflow(addNewChartWorkflow)
             )
         }
     }

--- a/app/src/main/kotlin/com/omricat/maplibrarian/DefaultDiContainer.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/DefaultDiContainer.kt
@@ -5,9 +5,9 @@ import com.omricat.maplibrarian.auth.AuthViewRegistry
 import com.omricat.maplibrarian.auth.AuthWorkflow
 import com.omricat.maplibrarian.auth.SignUpWorkflow
 import com.omricat.maplibrarian.chartlist.ActualChartsWorkflow
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow
 import com.omricat.maplibrarian.chartlist.ChartDetailsWorkflow
 import com.omricat.maplibrarian.chartlist.ChartsWorkflow
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow
 import com.omricat.maplibrarian.chartlist.MapListViewRegistry
 import com.omricat.maplibrarian.root.AuthorizedScreenLayoutRunner
 import com.squareup.workflow1.ui.ViewRegistry
@@ -25,13 +25,13 @@ abstract class DefaultDiContainer : DiContainer {
             )
         }
 
-        override val addNewChartWorkflow by lazy { AddNewChartWorkflow(chartsService) }
+        override val editChartDetailsWorkflow by lazy { EditChartDetailsWorkflow(chartsService) }
 
         override val charts: ChartsWorkflow by lazy {
             ActualChartsWorkflow(
                 chartsService,
-                addNewChartWorkflow,
-                ChartDetailsWorkflow(addNewChartWorkflow)
+                editChartDetailsWorkflow,
+                ChartDetailsWorkflow(editChartDetailsWorkflow)
             )
         }
     }

--- a/app/src/main/kotlin/com/omricat/maplibrarian/MapLibraryApp.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/MapLibraryApp.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import com.google.firebase.FirebaseApp
 import com.omricat.maplibrarian.auth.AuthService
 import com.omricat.maplibrarian.auth.AuthWorkflow
+import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow
 import com.omricat.maplibrarian.chartlist.ChartsService
 import com.omricat.maplibrarian.chartlist.ChartsWorkflow
 import com.squareup.workflow1.ui.ViewRegistry
@@ -34,6 +35,7 @@ interface DiContainer {
     interface Workflows {
         val auth: AuthWorkflow
         val charts: ChartsWorkflow
+        val addNewChartWorkflow: AddNewChartWorkflow
     }
 }
 

--- a/app/src/main/kotlin/com/omricat/maplibrarian/MapLibraryApp.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/MapLibraryApp.kt
@@ -7,9 +7,9 @@ import android.content.Context
 import com.google.firebase.FirebaseApp
 import com.omricat.maplibrarian.auth.AuthService
 import com.omricat.maplibrarian.auth.AuthWorkflow
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow
 import com.omricat.maplibrarian.chartlist.ChartsService
 import com.omricat.maplibrarian.chartlist.ChartsWorkflow
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow
 import com.squareup.workflow1.ui.ViewRegistry
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
@@ -35,7 +35,7 @@ interface DiContainer {
     interface Workflows {
         val auth: AuthWorkflow
         val charts: ChartsWorkflow
-        val addNewChartWorkflow: AddNewChartWorkflow
+        val editChartDetailsWorkflow: EditChartDetailsWorkflow
     }
 }
 

--- a/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/AddItemScreenViewFactory.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/AddItemScreenViewFactory.kt
@@ -9,7 +9,7 @@ import com.squareup.workflow1.ui.setTextChangedListener
 import com.squareup.workflow1.ui.updateText
 
 @OptIn(WorkflowUiExperimentalApi::class)
-internal object AddItemScreenViewFactory : ViewFactory<AddItemScreen> by bind(
+internal object AddItemScreenViewFactory : ViewFactory<EditItemScreen> by bind(
     bindingInflater = EditChartBinding::inflate,
     showRendering = { screen, _ ->
         editTitle.updateText(screen.chart.title)
@@ -29,7 +29,7 @@ internal object SavingItemScreenViewFactory : ViewFactory<SavingItemScreen> by b
 
 @WorkflowUiExperimentalApi
 private fun EditChartBinding.enableSaveAndDiscard(
-    screen: AddItemScreen?
+    screen: EditItemScreen?
 ) {
     fun (() -> Unit).asClickListener(): (View) -> Unit = { _ ->
         this.invoke()

--- a/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsViewFactories.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsViewFactories.kt
@@ -22,6 +22,6 @@ internal val MapListViewRegistry = ViewRegistry(
     ChartListLoadingViewFactory,
     ChartErrorViewFactory,
     ChartListLayoutRunner,
-    AddItemScreenViewFactory,
+    EditChartDetailsScreenViewFactory,
     SavingItemScreenViewFactory
 )

--- a/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/EditChartDetailsScreenViewFactory.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/EditChartDetailsScreenViewFactory.kt
@@ -9,7 +9,7 @@ import com.squareup.workflow1.ui.setTextChangedListener
 import com.squareup.workflow1.ui.updateText
 
 @OptIn(WorkflowUiExperimentalApi::class)
-internal object AddItemScreenViewFactory : ViewFactory<EditItemScreen> by bind(
+internal object EditChartDetailsScreenViewFactory : ViewFactory<EditChartDetailsScreen> by bind(
     bindingInflater = EditChartBinding::inflate,
     showRendering = { screen, _ ->
         editTitle.updateText(screen.chart.title)
@@ -29,7 +29,7 @@ internal object SavingItemScreenViewFactory : ViewFactory<SavingItemScreen> by b
 
 @WorkflowUiExperimentalApi
 private fun EditChartBinding.enableSaveAndDiscard(
-    screen: EditItemScreen?
+    screen: EditChartDetailsScreen?
 ) {
     fun (() -> Unit).asClickListener(): (View) -> Unit = { _ ->
         this.invoke()

--- a/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsService.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsService.kt
@@ -70,7 +70,7 @@ class FirebaseChartsService(
 
     private fun FirebaseFirestore.mapsCollection(user: User) =
         collection("users")
-            .document(user.id.toString())
+            .document(user.id.id)
             .collection("maps")
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -13,14 +13,14 @@ kotlin {
 }
 
 dependencies {
-    implementation(KotlinX.coroutines.core)
+    api(KotlinX.coroutines.core)
 
     fun workflow(artifact: String) = "com.squareup.workflow1:workflow-$artifact:_"
-    implementation(workflow("core-jvm"))
+    api(workflow("core-jvm"))
 
-    implementation("com.michael-bull.kotlin-result:kotlin-result:_")
+    api("com.michael-bull.kotlin-result:kotlin-result:_")
 
-    implementation(KotlinX.serialization.json)
+    api(KotlinX.serialization.json)
 
     testImplementation(Testing.kotest.runner.junit5)
     testImplementation(Testing.kotest.assertions.core)

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartDetailsWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartDetailsWorkflow.kt
@@ -14,7 +14,7 @@ import com.squareup.workflow1.WorkflowAction
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
-public class ChartDetailsWorkflow(private val editChartWorkflow: AddNewChartWorkflow) :
+public class ChartDetailsWorkflow(private val editChartDetailsWorkflow: EditChartDetailsWorkflow) :
     StatefulWorkflow<Props, State, Nothing, ChartDetailsScreen>() {
 
     public data class Props(val user: User, val chart: DbChartModel)
@@ -56,8 +56,8 @@ public class ChartDetailsWorkflow(private val editChartWorkflow: AddNewChartWork
                 EditingOverlayDetailsScreen(
                     detailsScreen = showingChartDetailsScreen,
                     overlaidEditingScreen = context.renderChild(
-                        editChartWorkflow,
-                        props = AddNewChartWorkflow.Props(renderProps.user, renderState.chart)
+                        editChartDetailsWorkflow,
+                        props = EditChartDetailsWorkflow.Props(renderProps.user, renderState.chart)
                     ) { WorkflowAction.noAction() }
                 )
         }

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartDetailsWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartDetailsWorkflow.kt
@@ -1,0 +1,64 @@
+package com.omricat.maplibrarian.chartlist
+
+import com.omricat.maplibrarian.chartlist.ChartDetailsWorkflow.State
+import com.omricat.maplibrarian.chartlist.ChartDetailsWorkflow.State.EditingChart
+import com.omricat.maplibrarian.chartlist.ChartDetailsWorkflow.State.ShowingDetails
+import com.omricat.maplibrarian.model.DbChartModel
+import com.omricat.workflow.eventHandler
+import com.squareup.workflow1.Snapshot
+import com.squareup.workflow1.StatefulWorkflow
+import com.squareup.workflow1.action
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+public class ChartDetailsWorkflow(private val editChartWorkflow: AddNewChartWorkflow) :
+    StatefulWorkflow<DbChartModel, State, Nothing, ChartDetailsScreen>() {
+
+    @Serializable
+    public sealed class State {
+
+        @Serializable
+        public data class ShowingDetails(val chart: DbChartModel) : State()
+
+        public data class EditingChart(val chart: DbChartModel) : State()
+
+        internal companion object {
+            fun fromSnapshot(snapshot: Snapshot): State =
+                Json.decodeFromString(serializer(), snapshot.bytes.utf8())
+        }
+    }
+
+    override fun initialState(
+        props: DbChartModel,
+        snapshot: Snapshot?
+    ): State = snapshot?.let(State::fromSnapshot) ?: TODO()
+
+    override fun render(
+        renderProps: DbChartModel,
+        renderState: State,
+        context: RenderContext
+    ): ChartDetailsScreen = when (renderState) {
+        is ShowingDetails -> ChartDetailsScreen(
+            title = renderState.chart.title,
+            onEditPressed = context.eventHandler(onEdit(renderState))
+        )
+
+        is EditingChart ->
+            TODO()
+    }
+
+    private fun onEdit(renderState: ShowingDetails) = action {
+        state = EditingChart(renderState.chart)
+    }
+
+
+    override fun snapshotState(state: State): Snapshot = state.toSnapshot()
+}
+
+internal fun State.toSnapshot(): Snapshot =
+    Snapshot.of(Json.encodeToString(State.serializer(), this))
+
+public data class ChartDetailsScreen(
+    val title: String,
+    val onEditPressed: () -> Unit,
+) : ChartsScreen

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsService.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsService.kt
@@ -1,19 +1,18 @@
 package com.omricat.maplibrarian.chartlist
 
 import com.github.michaelbull.result.Result
+import com.omricat.maplibrarian.model.ChartModel
 import com.omricat.maplibrarian.model.DbChartModel
-import com.omricat.maplibrarian.model.UnsavedChartModel
 import com.omricat.maplibrarian.model.User
 import kotlinx.serialization.Serializable
 
 public interface ChartsService {
     public suspend fun chartsListForUser(user: User): Result<List<DbChartModel>, ChartsServiceError>
-    public suspend fun addNewChart(
+    public suspend fun <T : ChartModel<T>> saveChart(
         user: User,
-        newChart: UnsavedChartModel
+        newChart: ChartModel<T>
     ): Result<DbChartModel, ChartsServiceError>
 }
-
 
 @Serializable
 public data class ChartsServiceError(val message: String) {

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflow.kt
@@ -68,7 +68,10 @@ public class ActualChartsWorkflow(
             context.renderChild(showingDetailsWorkflow, props = renderState.chartModel)
 
         is AddingItem ->
-            context.renderChild(addNewChartWorkflow, props = renderProps.user) { onItemAdded() }
+            context.renderChild(
+                addNewChartWorkflow,
+                props = AddNewChartWorkflow.Props(renderProps.user)
+            ) { onItemAdded() }
 
         is ErrorLoadingCharts -> ShowError(renderState.error.message)
     }

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflow.kt
@@ -28,7 +28,7 @@ public interface ChartsWorkflow : Workflow<Props, Nothing, ChartsScreen>
 
 public class ActualChartsWorkflow(
     private val chartsService: ChartsService,
-    private val addNewChartWorkflow: AddNewChartWorkflow,
+    private val editChartDetailsWorkflow: EditChartDetailsWorkflow,
     private val showingDetailsWorkflow: ChartDetailsWorkflow
 ) : StatefulWorkflow<Props, ChartsWorkflowState, Nothing, ChartsScreen>(), ChartsWorkflow {
 
@@ -72,8 +72,8 @@ public class ActualChartsWorkflow(
 
         is AddingItem ->
             context.renderChild(
-                addNewChartWorkflow,
-                props = AddNewChartWorkflow.Props(renderProps.user)
+                editChartDetailsWorkflow,
+                props = EditChartDetailsWorkflow.Props(renderProps.user)
             ) { onItemAdded() }
 
         is ErrorLoadingCharts -> ShowError(renderState.error.message)

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflow.kt
@@ -65,7 +65,10 @@ public class ActualChartsWorkflow(
         }
 
         is ShowingDetails ->
-            context.renderChild(showingDetailsWorkflow, props = renderState.chartModel)
+            context.renderChild(
+                showingDetailsWorkflow,
+                props = ChartDetailsWorkflow.Props(renderProps.user, renderState.chartModel)
+            )
 
         is AddingItem ->
             context.renderChild(

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflowState.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflowState.kt
@@ -18,6 +18,9 @@ public sealed class ChartsWorkflowState {
     @Serializable
     public object AddingItem : ChartsWorkflowState()
 
+    @Serializable
+    public data class ShowingDetails(val chartModel: DbChartModel) : ChartsWorkflowState()
+
     public data class ErrorLoadingCharts(val error: ChartsServiceError) : ChartsWorkflowState()
 
     internal companion object

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/EditChartDetailsWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/EditChartDetailsWorkflow.kt
@@ -3,18 +3,18 @@ package com.omricat.maplibrarian.chartlist
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.map
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.Actions.OnDiscard
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.Actions.OnErrorSaving
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.Actions.OnNewItemSaved
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.Actions.OnSave
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.Actions.OnTitleChanged
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.Event
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.Event.Discard
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.Event.Saved
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.Props
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.State
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.State.Editing
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.State.Saving
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.Actions.OnDiscard
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.Actions.OnErrorSaving
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.Actions.OnNewItemSaved
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.Actions.OnSave
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.Actions.OnTitleChanged
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.Event
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.Event.Discard
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.Event.Saved
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.Props
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.State
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.State.Editing
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.State.Saving
 import com.omricat.maplibrarian.model.ChartModel
 import com.omricat.maplibrarian.model.DbChartModel
 import com.omricat.maplibrarian.model.UnsavedChartModel
@@ -30,7 +30,7 @@ import com.squareup.workflow1.runningWorker
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.StringFormat
 
-public class AddNewChartWorkflow(
+public class EditChartDetailsWorkflow(
     private val chartsService: ChartsService,
     serializationFormat: StringFormat = StateSnapshotSerializer.json
 ) :
@@ -74,7 +74,7 @@ public class AddNewChartWorkflow(
         context: RenderContext
     ): EditingItemScreen = when (renderState) {
         is Editing<*> -> {
-            EditItemScreen(
+            EditChartDetailsScreen(
                 chart = renderState.chart,
                 errorMessage = renderState.errorMessage,
                 onTitleChanged = { newTitle ->
@@ -140,7 +140,7 @@ public sealed interface EditingItemScreen : ChartsScreen {
     public val chart: ChartModel<*>
 }
 
-public data class EditItemScreen(
+public data class EditChartDetailsScreen(
     override val chart: ChartModel<*>,
     val errorMessage: String = "",
     val onTitleChanged: (CharSequence) -> Unit,

--- a/core/src/main/kotlin/com/omricat/maplibrarian/model/ChartModel.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/model/ChartModel.kt
@@ -1,11 +1,24 @@
 package com.omricat.maplibrarian.model
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.polymorphic
+import kotlinx.serialization.modules.subclass
 
 public sealed interface ChartModel<SelfT : ChartModel<SelfT>> {
     public val userId: UserUid
     public val title: String
     public fun clone(title: String = this.title): SelfT
+
+    public companion object {
+
+        public val serializerModule: SerializersModule = SerializersModule {
+            polymorphic(ChartModel::class) {
+                subclass(DbChartModel::class)
+                subclass(UnsavedChartModel::class)
+            }
+        }
+    }
 }
 
 @Serializable

--- a/core/src/main/kotlin/com/omricat/maplibrarian/model/ChartModel.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/model/ChartModel.kt
@@ -2,9 +2,10 @@ package com.omricat.maplibrarian.model
 
 import kotlinx.serialization.Serializable
 
-public sealed interface ChartModel {
+public sealed interface ChartModel<SelfT : ChartModel<SelfT>> {
     public val userId: UserUid
     public val title: String
+    public fun clone(title: String = this.title): SelfT
 }
 
 @Serializable
@@ -12,13 +13,17 @@ public data class DbChartModel(
     override val userId: UserUid,
     override val title: String,
     public val chartId: ChartId
-) : ChartModel
+) : ChartModel<DbChartModel> {
+    override fun clone(title: String): DbChartModel = copy(title = title)
+}
 
 @Serializable
 public data class UnsavedChartModel(
     override val userId: UserUid,
     override val title: String
-) : ChartModel
+) : ChartModel<UnsavedChartModel> {
+    override fun clone(title: String): UnsavedChartModel = copy(title = title)
+}
 
 @Serializable
 @JvmInline

--- a/core/src/main/kotlin/com/omricat/maplibrarian/model/ChartModelMapSerialization.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/model/ChartModelMapSerialization.kt
@@ -17,15 +17,15 @@ private object MapModelProperties {
     const val USER_ID = "userId"
 }
 
-public object ChartModelToMapSerializer : ToMapSerializer<UnsavedChartModel> {
-    override operator fun invoke(model: UnsavedChartModel): Map<String, String> =
+public object ChartModelToMapSerializer : ToMapSerializer<ChartModel<*>> {
+    override operator fun invoke(model: ChartModel<*>): Map<String, Any?> =
         hashMapOf(
             TITLE to model.title,
             USER_ID to model.userId.id
         )
 }
 
-public fun UnsavedChartModel.serializedToMap(): Map<String, Any?> =
+public fun ChartModel<*>.serializedToMap(): Map<String, Any?> =
     ChartModelToMapSerializer(this)
 
 public object DbChartModelFromMapDeserializer :

--- a/core/src/main/kotlin/com/omricat/workflow/AbstractWorkflowAction.kt
+++ b/core/src/main/kotlin/com/omricat/workflow/AbstractWorkflowAction.kt
@@ -1,0 +1,17 @@
+package com.omricat.workflow
+
+import com.squareup.workflow1.WorkflowAction
+
+/**
+ * Convenience class to make aid with defining actions as sealed classes.
+ *
+ * To use it, define an open class extending from it as a nested class of the Workflow.
+ */
+public abstract class AbstractWorkflowAction<PropsT, StateT, OutputT>(
+    private val name: () -> String,
+    private val updater: WorkflowAction<PropsT, StateT, OutputT>.Updater.() -> Unit
+) : WorkflowAction<PropsT, StateT, OutputT>() {
+    override fun Updater.apply(): Unit = updater.invoke(this)
+
+    override fun toString(): String = "WorkflowAction(${name()})@${hashCode()}"
+}

--- a/core/src/main/kotlin/com/omricat/workflow/StateSnapshots.kt
+++ b/core/src/main/kotlin/com/omricat/workflow/StateSnapshots.kt
@@ -1,0 +1,51 @@
+package com.omricat.workflow
+
+import com.omricat.maplibrarian.model.ChartModel
+import com.squareup.workflow1.Snapshot
+import com.squareup.workflow1.StatefulWorkflow
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationStrategy
+import kotlinx.serialization.StringFormat
+import kotlinx.serialization.json.Json
+
+public class StateSnapshotSerializer<T : Any> internal constructor(
+    private val serializationStrategy: SerializationStrategy<T>,
+    private val deserializationStrategy: DeserializationStrategy<T>,
+    private val serializationFormat: StringFormat
+) {
+    internal constructor(
+        serializationStrategy: KSerializer<T>,
+        serializationFormat: StringFormat
+    ) : this(
+        serializationStrategy,
+        serializationStrategy,
+        serializationFormat
+    )
+
+    public fun fromSnapshot(snapshot: Snapshot): T =
+        serializationFormat.decodeFromString(deserializationStrategy, snapshot.bytes.utf8())
+
+    public fun toSnapshot(value: T): Snapshot =
+        Snapshot.of(serializationFormat.encodeToString(serializationStrategy, value))
+
+    internal companion object {
+        internal val json = Json {
+            serializersModule = ChartModel.serializerModule
+        }
+    }
+}
+
+public abstract class StatefulWorkflowWithSnapshots<PropsT, StateT : Any, OutputT, RenderingT> :
+    StatefulWorkflow<PropsT, StateT, OutputT, RenderingT>() {
+
+    protected abstract val stateSnapshotSerializer: StateSnapshotSerializer<StateT>
+
+    protected abstract fun initialState(props: PropsT): StateT
+
+    override fun initialState(props: PropsT, snapshot: Snapshot?): StateT =
+        snapshot?.let { stateSnapshotSerializer.fromSnapshot(it) }
+            ?: initialState(props)
+
+    override fun snapshotState(state: StateT): Snapshot = stateSnapshotSerializer.toSnapshot(state)
+}

--- a/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/AddNewChartWorkflowTest.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/AddNewChartWorkflowTest.kt
@@ -3,12 +3,20 @@ package com.omricat.maplibrarian.chartlist
 import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.State
 import com.omricat.maplibrarian.model.UnsavedChartModel
 import com.omricat.maplibrarian.model.UserUid
+import com.omricat.workflow.StateSnapshotSerializer
+import com.squareup.workflow1.Snapshot
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
 internal class AddNewChartWorkflowTest : WordSpec({
 
     "AddNewChartWorkflow.State#toSnapshot composed with fromSnapshot" should {
+
+        val stateSerializer = State.snapshotSerializer(StateSnapshotSerializer.json)
+
+        fun State.toSnapshot() = stateSerializer.toSnapshot(this)
+        fun State.Companion.fromSnapshot(snapshot: Snapshot) =
+            stateSerializer.fromSnapshot(snapshot)
 
         val chart = UnsavedChartModel(UserUid("user"), "title")
 

--- a/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflowTest.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflowTest.kt
@@ -9,6 +9,10 @@ import io.kotest.matchers.shouldBe
 internal class ChartsWorkflowTest : WordSpec({
 
     "ChartsState.toSnapshot composed with fromSnapshot" should {
+        val dbChart = DbChartModel(
+            UserUid("user"), "title",
+            ChartId("chart")
+        )
         "be the identity for RequestData" {
             val state = ChartsWorkflowState.RequestData
 
@@ -21,15 +25,8 @@ internal class ChartsWorkflowTest : WordSpec({
             ChartsWorkflowState.fromSnapshot(state.toSnapshot()) shouldBe state
         }
 
-        "be the identity for AddingItem" {
-            val state = ChartsWorkflowState.ChartsListLoaded(
-                listOf(
-                    DbChartModel(
-                        UserUid("user"), "title",
-                        ChartId("chart")
-                    )
-                )
-            )
+        "be the identity for ChartsListLoaded" {
+            val state = ChartsWorkflowState.ChartsListLoaded(listOf(dbChart))
 
             ChartsWorkflowState.fromSnapshot(state.toSnapshot()) shouldBe state
         }
@@ -39,6 +36,12 @@ internal class ChartsWorkflowTest : WordSpec({
 
             ChartsWorkflowState.fromSnapshot(state.toSnapshot()) shouldBe
                 ChartsWorkflowState.RequestData
+        }
+
+        "be the identity for ShowingDetails" {
+            val state = ChartsWorkflowState.ShowingDetails(dbChart)
+
+            ChartsWorkflowState.fromSnapshot(state.toSnapshot()) shouldBe state
         }
     }
 })

--- a/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/EditChartDetailsWorkflowTest.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/EditChartDetailsWorkflowTest.kt
@@ -1,6 +1,6 @@
 package com.omricat.maplibrarian.chartlist
 
-import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.State
+import com.omricat.maplibrarian.chartlist.EditChartDetailsWorkflow.State
 import com.omricat.maplibrarian.model.UnsavedChartModel
 import com.omricat.maplibrarian.model.UserUid
 import com.omricat.workflow.StateSnapshotSerializer
@@ -8,9 +8,9 @@ import com.squareup.workflow1.Snapshot
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-internal class AddNewChartWorkflowTest : WordSpec({
+internal class EditChartDetailsWorkflowTest : WordSpec({
 
-    "AddNewChartWorkflow.State#toSnapshot composed with fromSnapshot" should {
+    "EditChartDetailsWorkflow.State#toSnapshot composed with fromSnapshot" should {
 
         val stateSerializer = State.snapshotSerializer(StateSnapshotSerializer.json)
 


### PR DESCRIPTION
- Add ChartDetailsWorkflow to manage displaying details for selected chart
- Introduce AddNewChartWorkflow.Props to allow providing the workflow with a chart to be edited
- Change ChartModel to give it a clone method returning a "self" type
- Introduce AbstractWorkflowAction to try to simplify declaring WorkflowActions as classes Refactor actions in ChartDetailsWorkflow and SignUpWorkflow to test out AbstractWorkflowAction
- Introduce StatefulWorkflowWithSnapshots to simplify snapshot creation, particularly when the workflow's state refers to polymorphic fields
- refactor(core): Define actions in AddNewChartWorkflow as classes
- refactor(core): Rename AddNewChartWorkflow to EditChartDetailsWorkflow
- fix(core): Expose core's dependencies to consumers
- fix(app): Correctly build firebase query
