### PR TITLE
First pass at integration tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -99,6 +99,8 @@ dependencies {
 
     testImplementation(Testing.kotest.runner.junit5)
     testImplementation(Testing.kotest.assertions.core)
+    testImplementation(Testing.kotestExtensions.robolectric)
+    testImplementation(AndroidX.test.ext.junit)
 
     testImplementation(workflow("testing-jvm"))
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,8 +55,8 @@ android {
     }
 
     testOptions {
-        unitTests.all {
-            it.useJUnitPlatform()
+        unitTests {
+            isIncludeAndroidResources = true
         }
     }
 }
@@ -97,10 +97,19 @@ dependencies {
 
     compileOnly("dev.ahmedmourad.nocopy:nocopy-annotations:_")
 
-    testImplementation(Testing.kotest.runner.junit5)
+    testImplementation(KotlinX.coroutines.test)
+
     testImplementation(Testing.kotest.assertions.core)
-    testImplementation(Testing.kotestExtensions.robolectric)
-    testImplementation(AndroidX.test.ext.junit)
+    testImplementation(Testing.robolectric)
+    testImplementation(Testing.junit4)
+
+    testImplementation(platform("org.testcontainers:testcontainers-bom:_"))
+    testImplementation("org.testcontainers:testcontainers")
+    testImplementation("org.testcontainers:gcloud")
+    testImplementation("org.slf4j:slf4j-simple:_") // for testcontainers logs
+
+    testImplementation(AndroidX.test.ext.junitKtx)
+    testImplementation(AndroidX.test.coreKtx)
 
     testImplementation(workflow("testing-jvm"))
 

--- a/app/src/test/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsServiceIntegrationTest.kt
+++ b/app/src/test/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsServiceIntegrationTest.kt
@@ -1,0 +1,8 @@
+package com.omricat.maplibrarian.chartlist
+
+import org.junit.jupiter.api.Assertions.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class FirebaseChartsServiceIntegrationTest {
+

--- a/app/src/test/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsServiceIntegrationTest.kt
+++ b/app/src/test/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsServiceIntegrationTest.kt
@@ -3,9 +3,14 @@ package com.omricat.maplibrarian.chartlist
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
 import com.google.firebase.FirebaseApp
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestoreSettings
+import com.omricat.maplibrarian.auth.AuthError
+import com.omricat.maplibrarian.auth.AuthService
+import com.omricat.maplibrarian.auth.Credential
+import com.omricat.maplibrarian.auth.EmailPasswordCredential
 import com.omricat.maplibrarian.model.DbChartModel
 import com.omricat.maplibrarian.model.UnsavedChartModel
 import com.omricat.maplibrarian.model.User
@@ -19,6 +24,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -38,31 +44,48 @@ class FirebaseChartsServiceIntegrationTest {
 
     private val testScheduler = TestCoroutineScheduler()
 
-    private val dispatcherProvider = object : DefaultDispatcherProvider() {
+    private val testDispatcherProvider = object : DefaultDispatcherProvider() {
+        private val dispatcher = StandardTestDispatcher(testScheduler)
+        override val default: CoroutineDispatcher
+            get() = dispatcher
+        override val main: CoroutineDispatcher
+            get() = dispatcher
+        override val unconfined: CoroutineDispatcher
+            get() = dispatcher
         override val io: CoroutineDispatcher
-            get() = StandardTestDispatcher(testScheduler)
+            get() = dispatcher
     }
 
-    private val user = object : User {
-        override val displayName: String = "User 1"
-        override val id: UserUid = UserUid("XbmeeiiyihVjM5aBtVT0frNiGall")
+    /*
+        See https://github.com/Kotlin/kotlinx.coroutines/issues/3173
+     */
+    @Before
+    fun coroutinesWorkaround() {
+        System.setProperty("kotlinx.coroutines.main.delay", "false")
     }
 
     @Before
     fun beforeTest() {
-        FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
-        firestoreInstance = FirebaseFirestore.getInstance().apply {
-            firestoreSettings = firestoreSettings {
-                isPersistenceEnabled = false
+        firestoreInstance =
+            FirebaseFirestore.getInstance(
+                FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())!!
+            ).apply {
+                firestoreSettings = firestoreSettings {
+                    isPersistenceEnabled = false
+                }
+                useEmulator(emulator.host, emulator.getMappedPort(8080))
             }
-            useEmulator(emulator.host, emulator.getMappedPort(8080))
-        }
+    }
+
+    @After
+    fun afterTest() {
+        firestoreInstance.terminate()
     }
 
     @Test
     fun insertAndQuery() {
-        val service = FirebaseChartsService(firestoreInstance, dispatcherProvider)
-        runTest(context = dispatcherProvider.io) {
+        val service = FirebaseChartsService(firestoreInstance, testDispatcherProvider)
+        runTest(context = testDispatcherProvider.io) {
 
             // Add charts to repository
             for (i in 1..3) {
@@ -77,14 +100,57 @@ class FirebaseChartsServiceIntegrationTest {
             }
         }
     }
+
+    @Test
+    fun `create user then add chart and query added chart`() {
+        val authService: AuthService = TestAuthService()
+
+        val chartsService = FirebaseChartsService(firestoreInstance, testDispatcherProvider)
+
+        runTest(context = testScheduler, dispatchTimeoutMs = 15_000) {
+            val createUserResult: Result<User, AuthError> =
+                authService.createUser(EmailPasswordCredential("user1@example.com", "password"))
+            createUserResult.shouldBeInstanceOf<Ok<User>>()
+            val user = createUserResult.value
+
+            chartsService.addNewChart(user, UnsavedChartModel(user.id, "Chart"))
+                .shouldBeInstanceOf<Ok<DbChartModel>>()
+
+            val queryChartsResult: Result<List<DbChartModel>, ChartsServiceError> =
+                chartsService.chartsListForUser(user)
+
+            queryChartsResult.shouldBeInstanceOf<Ok<List<DbChartModel>>>()
+            queryChartsResult.value.should {
+                it.shouldHaveSize(1)
+            }
+        }
+    }
+}
+
+private val user = object : User {
+    override val displayName: String = "User 1"
+    override val id: UserUid = UserUid("XbmeeiiyihVjM5aBtVT0frNiGall")
 }
 
 class FirebaseEmulatorContainer : GenericContainer<FirebaseEmulatorContainer>(
-    DockerImageName.parse("ghcr.io/grodin/firebase-emulator-docker:v1.1.0")
+    DockerImageName.parse("ghcr.io/grodin/firebase-emulator-docker:v1.2.0")
 ) {
     init {
-        withExposedPorts(8080, 9091)
+        withExposedPorts(8080, 9099)
         waitingFor(Wait.forHealthcheck())
         withCommand("emulators:start")
     }
+}
+
+internal class TestAuthService : AuthService {
+    override suspend fun attemptAuthentication(credential: Credential): Result<User, AuthError> =
+        throw UnsupportedOperationException()
+
+    override fun signOut(): Unit = throw UnsupportedOperationException()
+
+    override suspend fun getSignedInUserIfAny(): Result<User?, AuthError> =
+        throw UnsupportedOperationException()
+
+    override suspend fun createUser(credential: Credential): Result<User, AuthError> =
+        Ok(user)
 }

--- a/app/src/test/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsServiceIntegrationTest.kt
+++ b/app/src/test/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsServiceIntegrationTest.kt
@@ -1,8 +1,82 @@
 package com.omricat.maplibrarian.chartlist
 
-import org.junit.jupiter.api.Assertions.*
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.michaelbull.result.Ok
+import com.google.firebase.FirebaseApp
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestoreSettings
+import com.omricat.maplibrarian.model.DbChartModel
+import com.omricat.maplibrarian.model.UnsavedChartModel
+import com.omricat.maplibrarian.model.User
+import com.omricat.maplibrarian.model.UserUid
+import com.omricat.maplibrarian.utils.DispatcherProvider.DefaultDispatcherProvider
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.should
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.testcontainers.containers.FirestoreEmulatorContainer
+import org.testcontainers.utility.DockerImageName
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class FirebaseChartsServiceIntegrationTest {
 
+    @get:Rule
+    val emulator =
+        FirestoreEmulatorContainer(
+            DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:367.0.0-emulators")
+        )
+
+    private lateinit var firestoreInstance: FirebaseFirestore
+
+    private val testScheduler = TestCoroutineScheduler()
+
+    private val dispatcherProvider = object : DefaultDispatcherProvider() {
+        override val io: CoroutineDispatcher
+            get() = StandardTestDispatcher(testScheduler)
+    }
+
+    private val user = object : User {
+        override val displayName: String = "User 1"
+        override val id: UserUid = UserUid("XbmeeiiyihVjM5aBtVT0frNiGall")
+    }
+
+    @Before
+    fun beforeTest() {
+        FirebaseApp.initializeApp(ApplicationProvider.getApplicationContext())
+        firestoreInstance = FirebaseFirestore.getInstance().apply {
+            firestoreSettings = firestoreSettings {
+                isPersistenceEnabled = false
+            }
+            useEmulator(emulator.host, emulator.getMappedPort(8080))
+        }
+    }
+
+    @Test
+    fun insertAndQuery() {
+        val service = FirebaseChartsService(firestoreInstance, dispatcherProvider)
+        runTest(context = dispatcherProvider.io) {
+
+            // Add charts to repository
+            for (i in 1..3) {
+                service.addNewChart(user, UnsavedChartModel(user.id, "Chart $i"))
+            }
+
+            // Read back from repository
+            val chartsResult = service.chartsListForUser(user)
+            chartsResult.shouldBeInstanceOf<Ok<List<DbChartModel>>>()
+            chartsResult.value.should {
+                it.shouldHaveSize(3)
+            }
+        }
+    }
+}

--- a/app/src/test/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsServiceIntegrationTest.kt
+++ b/app/src/test/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsServiceIntegrationTest.kt
@@ -23,7 +23,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.testcontainers.containers.FirestoreEmulatorContainer
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -31,10 +32,7 @@ import org.testcontainers.utility.DockerImageName
 class FirebaseChartsServiceIntegrationTest {
 
     @get:Rule
-    val emulator =
-        FirestoreEmulatorContainer(
-            DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:367.0.0-emulators")
-        )
+    val emulator = FirebaseEmulatorContainer()
 
     private lateinit var firestoreInstance: FirebaseFirestore
 
@@ -78,5 +76,15 @@ class FirebaseChartsServiceIntegrationTest {
                 it.shouldHaveSize(3)
             }
         }
+    }
+}
+
+class FirebaseEmulatorContainer : GenericContainer<FirebaseEmulatorContainer>(
+    DockerImageName.parse("ghcr.io/grodin/firebase-emulator-docker:v1.1.0")
+) {
+    init {
+        withExposedPorts(8080, 9091)
+        waitingFor(Wait.forHealthcheck())
+        withCommand("emulators:start")
     }
 }

--- a/core/src/main/kotlin/com/omricat/maplibrarian/utils/DispatcherProvider.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/utils/DispatcherProvider.kt
@@ -10,7 +10,9 @@ public interface DispatcherProvider {
     public val main: CoroutineDispatcher
     public val unconfined: CoroutineDispatcher
 
-    public companion object Default : DispatcherProvider {
+    public companion object Default : DefaultDispatcherProvider()
+
+    public abstract class DefaultDispatcherProvider : DispatcherProvider {
         override val default: CoroutineDispatcher get() = Dispatchers.Default
         override val io: CoroutineDispatcher get() = Dispatchers.IO
         override val main: CoroutineDispatcher get() = Dispatchers.Main

--- a/versions.properties
+++ b/versions.properties
@@ -31,6 +31,8 @@ version.androidx.lifecycle=2.4.0
 
 version.androidx.recyclerview=1.1.0
 
+version.androidx.test.core=1.4.0
+
 version.androidx.test.rules=1.2.0
 
 version.com.google.gms..google-services=4.3.10
@@ -49,15 +51,21 @@ version.google.android.material=1.2.1
 
 version.jakewharton.timber=5.0.1
 
-version.kotest=5.1.0
+version.junit.junit=4.13.2
 
-version.kotest.extensions.robolectric=0.5.0
+version.kotest=5.1.0
 
 version.kotlin=1.6.10
 
 version.kotlinx.coroutines=1.6.0
 
 version.kotlinx.serialization=1.3.1
+
+version.org.slf4j..slf4j-simple=1.7.36
+
+version.org.testcontainers..testcontainers-bom=1.16.3
+
+version.robolectric=4.7.3
 
 version.workflow1=1.0.0
 

--- a/versions.properties
+++ b/versions.properties
@@ -49,7 +49,7 @@ version.google.android.material=1.2.1
 
 version.jakewharton.timber=5.0.1
 
-version.kotest=4.6.3
+version.kotest=5.1.0
 
 version.kotlin=1.6.10
 

--- a/versions.properties
+++ b/versions.properties
@@ -53,7 +53,7 @@ version.kotest=4.6.3
 
 version.kotlin=1.6.10
 
-version.kotlinx.coroutines=1.5.1
+version.kotlinx.coroutines=1.6.0
 
 version.kotlinx.serialization=1.3.1
 

--- a/versions.properties
+++ b/versions.properties
@@ -51,7 +51,7 @@ version.jakewharton.timber=5.0.1
 
 version.kotest=4.6.3
 
-version.kotlin=1.5.31
+version.kotlin=1.6.10
 
 version.kotlinx.coroutines=1.5.1
 

--- a/versions.properties
+++ b/versions.properties
@@ -51,6 +51,8 @@ version.jakewharton.timber=5.0.1
 
 version.kotest=5.1.0
 
+version.kotest.extensions.robolectric=0.5.0
+
 version.kotlin=1.6.10
 
 version.kotlinx.coroutines=1.6.0


### PR DESCRIPTION
- Bump kotlin from v1.5.31 to v1.6.10
- Bump kotlinx.coroutines from v1.5.1 to v1.6.0
- Bump kotest from v4.6.3 to v5.1.0
- build(app): add Roboelectric as a test dependency
- refactor(app): Switch integration tests from kotest to junit4 There isn't an obvious way of using the Android JUnit runner with kotest so the tests in :app now use JUnit4
- refactor(app): Slight refactor of DispatcherProvider
- test(app): Simple end-to-end test for FirebaseChartsService
- test(app): Switch to grodin/firebase-emulator-docker container
