### PR TITLE
Bump AGP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,9 +45,9 @@ android {
     }
 
     lint {
-        isWarningsAsErrors = false
-        isAbortOnError = false
-        disable("GradleDependency")
+        warningsAsErrors = false
+        abortOnError = false
+        disable += listOf("GradleDependency")
     }
 
     buildFeatures {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     plugins {
-        id("de.fayard.refreshVersions") version "0.40.0"
+        id("de.fayard.refreshVersions") version "0.40.1"
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,7 @@ pluginManagement {
 }
 
 plugins {
-    id("de.fayard.refreshVersions") version "0.40.0"
+    id("de.fayard.refreshVersions") version "0.40.1"
 }
 
 refreshVersions {

--- a/versions.properties
+++ b/versions.properties
@@ -9,7 +9,7 @@
 ####
 #### NOTE: Some versions are filtered by the rejectVersionsIf predicate. See the settings.gradle.kts file.
 
-plugin.android=7.0.4
+plugin.android=7.1.2
 
 plugin.dev.ahmedmourad.nocopy.nocopy-gradle-plugin=1.4.0
 

--- a/versions.properties
+++ b/versions.properties
@@ -79,6 +79,6 @@ version.androidx.test.espresso=3.2.0
 
 version.androidx.test.ext.junit=1.1.1
 
-plugin.com.autonomousapps.dependency-analysis=0.78.0
+plugin.com.autonomousapps.dependency-analysis=0.80.0
 
 version.com.pinterest..ktlint=0.42.1


### PR DESCRIPTION
- Bump refreshVersions from v0.40.0 to v0.40.1
- Bump AGP from v7.1.2 to v7.0.4
- Bump gradle dependency analysis plugin from v0.78.0 to v0.80.0
