### PR TITLE
First run at optimizing build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint")
     id("com.dorongold.task-tree")
     id("com.autonomousapps.dependency-analysis")
+    id("com.osacky.doctor")
     idea
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ org.gradle.jvmargs=-Xmx3G -Dkotlin.daemon.jvm.options\="-Xmx3G" -XX:+UseParallel
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
+org.gradle.unsafe.configuration-cache=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 android.useAndroidX=true
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M" -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx3G -Dkotlin.daemon.jvm.options\="-Xmx3G" -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -XX:MaxMetaspaceSize\=1G
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,6 +12,6 @@
 org.gradle.parallel=true
 android.useAndroidX=true
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M" -XX:+UseParallelGC
 org.gradle.caching=true
 org.gradle.configureondemand=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,9 +9,9 @@
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-org.gradle.parallel=true
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M" -XX:+UseParallelGC
+org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configureondemand=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,6 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
-android.enableJetifier=true
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,15 @@ pluginManagement {
 }
 
 plugins {
+    id("com.gradle.enterprise") version "3.12.2"
     id("de.fayard.refreshVersions") version "0.51.0"
+}
+
+gradleEnterprise {
+    buildScan {
+        termsOfServiceUrl = "https://gradle.com/terms-of-service"
+        termsOfServiceAgree = "yes"
+    }
 }
 
 refreshVersions {

--- a/versions.properties
+++ b/versions.properties
@@ -83,6 +83,6 @@ version.androidx.test.espresso=3.2.0
 
 version.androidx.test.ext.junit=1.1.1
 
-plugin.com.autonomousapps.dependency-analysis=0.80.0
+plugin.com.autonomousapps.dependency-analysis=1.18.0
 
 version.com.pinterest..ktlint=0.42.1

--- a/versions.properties
+++ b/versions.properties
@@ -9,8 +9,8 @@
 ####
 #### NOTE: Some versions are filtered by the rejectVersionsIf predicate. See the settings.gradle.kts file.
 
+## unused
 plugin.android=7.3.1
-
 
 plugin.io.gitlab.arturbosch.detekt=1.18.1
 
@@ -25,6 +25,9 @@ version.androidx.appcompat=1.2.0
 version.androidx.constraintlayout=2.1.3
 
 version.androidx.core=1.7.0
+
+## unused
+version.androidx.databinding=7.3.1
 
 version.androidx.datastore=1.0.0
 
@@ -42,12 +45,16 @@ version.com.google.gms..google-services=4.3.10
 
 version.com.jakewharton..process-phoenix=2.1.2
 
+## unused
 version.com.jakewharton.timber..timber=5.0.1
 
 version.com.michael-bull.kotlin-result..kotlin-result=1.1.14
 
 version.com.michael-bull.kotlin-result..kotlin-result-coroutines=1.1.14
 
+## unused
+
+## unused
 
 version.firebase-bom=29.0.0
 
@@ -60,6 +67,8 @@ version.junit.junit=4.13.2
 version.kotest=5.1.0
 
 version.kotlin=1.6.10
+
+## unused
 
 version.kotlinx.coroutines=1.6.0
 
@@ -75,8 +84,10 @@ version.workflow1=1.6.0
 
 plugin.com.dorongold.task-tree=2.1.0
 
+## unused
 plugin.org.gradle.kotlin.kotlin-dsl=2.1.4
 
+## unused
 version.androidx.test=1.2.0
 
 version.androidx.test.espresso=3.2.0
@@ -86,3 +97,5 @@ version.androidx.test.ext.junit=1.1.1
 plugin.com.autonomousapps.dependency-analysis=1.18.0
 
 version.com.pinterest..ktlint=0.42.1
+
+plugin.com.osacky.doctor=0.8.1


### PR DESCRIPTION
- build: Bump dependency-analysis plugin from v0.80.0 to v1.18.0
- build: Add gradle doctor plugin
- build: Add gradle enterprise plugin
- build: Disable jetifier
- build: Use parallel gc in gradle jvm args
- build: Sort gradle.properties file
- build: Tweak gradle jvmargs
- build: Use gradle configuration caching
