### PR TITLE
fix: Revert commit baeba77a0, downgrade kotlin to v1.6.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,15 @@ subprojects {
         isDownloadSources = true
     }
 
-     afterEvaluate {
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+        kotlinOptions {
+            freeCompilerArgs = listOf(
+                "-Xopt-in=kotlin.RequiresOptIn",
+            )
+            languageVersion = "1.5"
+        }
+    }
+    afterEvaluate {
         val hasKotlin = plugins.any {
             it is org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
         }

--- a/versions.properties
+++ b/versions.properties
@@ -59,7 +59,7 @@ version.junit.junit=4.13.2
 
 version.kotest=5.1.0
 
-version.kotlin=1.8.0
+version.kotlin=1.6.10
 
 version.kotlinx.coroutines=1.6.0
 


### PR DESCRIPTION
This reverts commit baeba77a0f0cd3204bdd4bc11ed206b441b45735.

Kotest is not yet compatible with kotlin v1.8.0, see [tracking issue](https://github.com/kotest/kotest/issues/3372).
