### PR TITLE
chore: Bump AGP from v7.3.1 to v7.4.1

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,9 @@ rootProject.name = ("map-librarian")
 include(
     ":app",
     ":core",
-    "kotlin-result-kotest",
+    ":kotlin-result-kotest",
     ":firebase-emulator-container",
+    ":firebase:auth",
+    //TODO: Create firebase:auth subproject to hold firebase auth integration code/tests
+    // see https://github.com/grodin/map-librarian/issues/82
 )

--- a/versions.properties
+++ b/versions.properties
@@ -10,7 +10,7 @@
 #### NOTE: Some versions are filtered by the rejectVersionsIf predicate. See the settings.gradle.kts file.
 
 ## unused
-plugin.android=7.3.1
+plugin.android=7.4.1
 
 plugin.io.gitlab.arturbosch.detekt=1.18.1
 


### PR DESCRIPTION
- style: Clean up settings.gradle.kts
- chore: Bump AGP from v7.3.1 to v7.4.1
