### PR TITLE
chore: Bump kotlin from v1.6.10 to v1.7.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,14 +45,6 @@ subprojects {
         }
     }
 
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions {
-            freeCompilerArgs =
-                listOf(
-                    "-Xopt-in=kotlin.RequiresOptIn",
-                )
-        }
-    }
     afterEvaluate {
         val hasKotlin =
             plugins.any { it is org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -4,3 +4,5 @@ pluginManagement {
 }
 
 plugins { id("de.fayard.refreshVersions") }
+
+rootProject.name = "buildSrc"

--- a/versions.properties
+++ b/versions.properties
@@ -64,7 +64,7 @@ version.jakewharton.timber=5.0.1
 
 version.junit.junit=4.13.2
 
-version.kotest=5.1.0
+version.kotest=5.5.5
 
 version.kotlin=1.7.21
 

--- a/versions.properties
+++ b/versions.properties
@@ -66,7 +66,7 @@ version.junit.junit=4.13.2
 
 version.kotest=5.1.0
 
-version.kotlin=1.6.10
+version.kotlin=1.7.21
 
 ## unused
 


### PR DESCRIPTION
- chore: Silence gradle warning about buildSrc
- chore: Bump kotlin from v1.6.10 to v1.7.21
