### PR TITLE
Map Firebase exceptions relating to user creation to error types

### DIFF
--- a/app/src/debug/kotlin/com/omricat/maplibrarian/DI.kt
+++ b/app/src/debug/kotlin/com/omricat/maplibrarian/DI.kt
@@ -5,11 +5,11 @@ import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import com.omricat.maplibrarian.auth.FirebaseUserRepository
 import com.omricat.maplibrarian.auth.UserRepository
 import com.omricat.maplibrarian.chartlist.ChartsService
 import com.omricat.maplibrarian.chartlist.FirebaseChartsService
 import com.omricat.maplibrarian.debugdrawer.DebugPreferencesRepository
-import com.omricat.maplibrarian.firebase.auth.FirebaseUserRepository
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import kotlinx.coroutines.runBlocking
 

--- a/app/src/debug/kotlin/com/omricat/maplibrarian/DI.kt
+++ b/app/src/debug/kotlin/com/omricat/maplibrarian/DI.kt
@@ -5,11 +5,11 @@ import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
-import com.omricat.maplibrarian.auth.AuthService
+import com.omricat.maplibrarian.auth.UserRepository
 import com.omricat.maplibrarian.chartlist.ChartsService
 import com.omricat.maplibrarian.chartlist.FirebaseChartsService
 import com.omricat.maplibrarian.debugdrawer.DebugPreferencesRepository
-import com.omricat.maplibrarian.firebase.auth.FirebaseAuthService
+import com.omricat.maplibrarian.firebase.auth.FirebaseUserRepository
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 import kotlinx.coroutines.runBlocking
 
@@ -31,10 +31,10 @@ internal fun MapLibraryApp.initializeDI(): DiContainer =
             }
         }
 
-        override val authService: AuthService by lazy {
+        override val userRepository: UserRepository by lazy {
             FirebaseAuth.getInstance()
                 .useEmulator(firebaseEmulatorHost, FIREBASE_EMULATOR_AUTH_PORT)
-            FirebaseAuthService(Firebase.auth)
+            FirebaseUserRepository(Firebase.auth)
         }
         override val chartsService: ChartsService by lazy {
             FirebaseFirestore.getInstance()

--- a/app/src/main/kotlin/com/omricat/firebase/interop/RunCatchingFirebaseException.kt
+++ b/app/src/main/kotlin/com/omricat/firebase/interop/RunCatchingFirebaseException.kt
@@ -1,0 +1,24 @@
+package com.omricat.firebase.interop
+
+import com.github.michaelbull.result.Err
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.google.firebase.FirebaseException
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+@OptIn(ExperimentalContracts::class)
+public inline fun <V, reified E : FirebaseException> runCatchingFirebaseException(
+    block: () -> V
+): Result<V, E> {
+    contract { callsInPlace(block, InvocationKind.EXACTLY_ONCE) }
+
+    return try {
+        Ok(block())
+    } catch (e: FirebaseException) {
+
+        // Can't use generics in catch so suppress the detekt check
+        @Suppress("detekt:InstanceOfCheckForException") if (e !is E) throw e else Err(e)
+    }
+}

--- a/app/src/main/kotlin/com/omricat/maplibrarian/DefaultDiContainer.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/DefaultDiContainer.kt
@@ -19,7 +19,7 @@ abstract class DefaultDiContainer : DiContainer {
     override val workflows: DiContainer.Workflows =
         object : DiContainer.Workflows {
             override val auth: AuthWorkflow by lazy {
-                ActualAuthWorkflow(authService, SignUpWorkflow.instance(authService))
+                ActualAuthWorkflow(userRepository, SignUpWorkflow.instance(userRepository))
             }
 
             override val charts: ChartsWorkflow by lazy {

--- a/app/src/main/kotlin/com/omricat/maplibrarian/MapLibraryApp.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/MapLibraryApp.kt
@@ -5,8 +5,8 @@ package com.omricat.maplibrarian
 import android.app.Application
 import android.content.Context
 import com.google.firebase.FirebaseApp
-import com.omricat.maplibrarian.auth.AuthService
 import com.omricat.maplibrarian.auth.AuthWorkflow
+import com.omricat.maplibrarian.auth.UserRepository
 import com.omricat.maplibrarian.chartlist.ChartsService
 import com.omricat.maplibrarian.chartlist.ChartsWorkflow
 import com.squareup.workflow1.ui.ViewRegistry
@@ -29,7 +29,7 @@ class MapLibraryApp : Application() {
 }
 
 interface DiContainer {
-    val authService: AuthService
+    val userRepository: UserRepository
     val chartsService: ChartsService
     val workflows: Workflows
     val viewRegistry: ViewRegistry

--- a/app/src/main/kotlin/com/omricat/maplibrarian/firebase/auth/FirebaseUserRepository.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/firebase/auth/FirebaseUserRepository.kt
@@ -8,9 +8,9 @@ import com.github.michaelbull.result.mapError
 import com.github.michaelbull.result.toResultOr
 import com.google.firebase.auth.FirebaseAuth
 import com.omricat.maplibrarian.auth.AuthError
-import com.omricat.maplibrarian.auth.AuthService
 import com.omricat.maplibrarian.auth.Credential
 import com.omricat.maplibrarian.auth.EmailPasswordCredential
+import com.omricat.maplibrarian.auth.UserRepository
 import com.omricat.maplibrarian.model.EmailAddress
 import com.omricat.maplibrarian.model.User
 import com.omricat.maplibrarian.model.UserUid
@@ -18,10 +18,10 @@ import com.omricat.maplibrarian.utils.DispatcherProvider
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 
-public class FirebaseAuthService(
+public class FirebaseUserRepository(
     private val auth: FirebaseAuth,
     private val dispatchers: DispatcherProvider = DispatcherProvider.Default
-) : AuthService {
+) : UserRepository {
     override suspend fun getSignedInUserIfAny(): Result<User?, AuthError> =
         withContext(dispatchers.io) {
             runSuspendCatching { auth.currentUser }

--- a/app/src/main/kotlin/com/omricat/maplibrarian/root/MainActivity.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/root/MainActivity.kt
@@ -36,7 +36,7 @@ internal class MainViewModel(app: Application, private val savedState: SavedStat
         renderWorkflowIn(
             workflow =
                 RootWorkflow(
-                    diContainer.authService,
+                    diContainer.userRepository,
                     diContainer.workflows.auth,
                     diContainer.workflows.charts
                 ),

--- a/app/src/release/kotlin/com/omricat/maplibrarian/DI.kt
+++ b/app/src/release/kotlin/com/omricat/maplibrarian/DI.kt
@@ -3,10 +3,10 @@ package com.omricat.maplibrarian
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import com.omricat.maplibrarian.auth.FirebaseUserRepository
 import com.omricat.maplibrarian.auth.UserRepository
 import com.omricat.maplibrarian.chartlist.ChartsService
 import com.omricat.maplibrarian.chartlist.FirebaseChartsService
-import com.omricat.maplibrarian.firebase.auth.FirebaseUserRepository
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 /** Setup DI container for release variant */

--- a/app/src/release/kotlin/com/omricat/maplibrarian/DI.kt
+++ b/app/src/release/kotlin/com/omricat/maplibrarian/DI.kt
@@ -3,17 +3,19 @@ package com.omricat.maplibrarian
 import com.google.firebase.auth.ktx.auth
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
-import com.omricat.maplibrarian.auth.AuthService
+import com.omricat.maplibrarian.auth.UserRepository
 import com.omricat.maplibrarian.chartlist.ChartsService
 import com.omricat.maplibrarian.chartlist.FirebaseChartsService
-import com.omricat.maplibrarian.firebase.auth.FirebaseAuthService
+import com.omricat.maplibrarian.firebase.auth.FirebaseUserRepository
 import com.squareup.workflow1.ui.WorkflowUiExperimentalApi
 
 /** Setup DI container for release variant */
 @WorkflowUiExperimentalApi
 internal fun MapLibraryApp.initializeDI(): DiContainer =
     object : DefaultDiContainer() {
-        override val authService: AuthService by lazy { FirebaseAuthService(Firebase.auth) }
+        override val userRepository: UserRepository by lazy {
+            FirebaseUserRepository(Firebase.auth)
+        }
         override val chartsService: ChartsService by lazy {
             FirebaseChartsService(Firebase.firestore)
         }

--- a/core/src/main/kotlin/com/omricat/maplibrarian/auth/AuthWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/auth/AuthWorkflow.kt
@@ -84,7 +84,7 @@ public class ActualAuthWorkflow(
     // Don't need to store state of in progress sign in
     override fun snapshotState(state: State): Snapshot? = null
 
-    internal fun onAuthError(error: AuthError) = action {
+    internal fun onAuthError(error: UserRepository.Error) = action {
         state = LoginPrompt(errorMessage = error.message)
     }
 
@@ -98,10 +98,10 @@ public class ActualAuthWorkflow(
 
     internal val onSignUpClicked = action { state = SigningUp }
 
-    internal val resolveLoggedInStatusWorker: Worker<Result<User?, AuthError>>
-        get() = resultWorker(::AuthError) { userRepository.getSignedInUserIfAny() }
+    internal val resolveLoggedInStatusWorker: Worker<Result<User?, UserRepository.Error>>
+        get() = resultWorker(::ExceptionWrapperError) { userRepository.getSignedInUserIfAny() }
 
-    internal fun handlePossibleUserResult(result: Result<User?, AuthError>) =
+    internal fun handlePossibleUserResult(result: Result<User?, UserRepository.Error>) =
         result
             .map { maybeUser ->
                 maybeUser?.let { user -> onAuthenticated(user) } ?: onNoAuthenticatedUser
@@ -110,10 +110,10 @@ public class ActualAuthWorkflow(
 
     internal fun attemptAuthenticationWorker(
         credential: Credential
-    ): Worker<Result<User, AuthError>> =
-        resultWorker(::AuthError) { userRepository.attemptAuthentication(credential) }
+    ): Worker<Result<User, UserRepository.Error>> =
+        resultWorker(::ExceptionWrapperError) { userRepository.attemptAuthentication(credential) }
 
-    internal fun handleAuthenticationResult(result: Result<User, AuthError>) =
+    internal fun handleAuthenticationResult(result: Result<User, UserRepository.Error>) =
         result.map { user -> onAuthenticated(user) }.getOrElse { error -> onAuthError(error) }
 }
 

--- a/core/src/main/kotlin/com/omricat/maplibrarian/auth/AuthWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/auth/AuthWorkflow.kt
@@ -28,7 +28,7 @@ public sealed class AuthResult {
 public sealed interface AuthWorkflow : Workflow<Unit, AuthResult, AuthorizingScreen>
 
 public class ActualAuthWorkflow(
-    private val authService: AuthService,
+    private val userRepository: UserRepository,
     private val signUpWorkflow: SignUpWorkflow
 ) :
     AuthWorkflow,
@@ -99,7 +99,7 @@ public class ActualAuthWorkflow(
     internal val onSignUpClicked = action { state = SigningUp }
 
     internal val resolveLoggedInStatusWorker: Worker<Result<User?, AuthError>>
-        get() = resultWorker(::AuthError) { authService.getSignedInUserIfAny() }
+        get() = resultWorker(::AuthError) { userRepository.getSignedInUserIfAny() }
 
     internal fun handlePossibleUserResult(result: Result<User?, AuthError>) =
         result
@@ -111,7 +111,7 @@ public class ActualAuthWorkflow(
     internal fun attemptAuthenticationWorker(
         credential: Credential
     ): Worker<Result<User, AuthError>> =
-        resultWorker(::AuthError) { authService.attemptAuthentication(credential) }
+        resultWorker(::AuthError) { userRepository.attemptAuthentication(credential) }
 
     internal fun handleAuthenticationResult(result: Result<User, AuthError>) =
         result.map { user -> onAuthenticated(user) }.getOrElse { error -> onAuthError(error) }

--- a/core/src/main/kotlin/com/omricat/maplibrarian/auth/SignUpWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/auth/SignUpWorkflow.kt
@@ -22,12 +22,12 @@ import com.squareup.workflow1.runningWorker
 
 public interface SignUpWorkflow : Workflow<Unit, SignUpOutput, SignUpScreen> {
     public companion object {
-        public fun instance(authService: AuthService): SignUpWorkflow =
-            ActualSignUpWorkflow(authService)
+        public fun instance(userRepository: UserRepository): SignUpWorkflow =
+            ActualSignUpWorkflow(userRepository)
     }
 }
 
-internal class ActualSignUpWorkflow(private val authService: AuthService) :
+internal class ActualSignUpWorkflow(private val userRepository: UserRepository) :
     StatefulWorkflow<Unit, State, SignUpOutput, SignUpScreen>(), SignUpWorkflow {
     override fun initialState(props: Unit, snapshot: Snapshot?): State = SignUpPrompt()
 
@@ -81,7 +81,7 @@ internal class ActualSignUpWorkflow(private val authService: AuthService) :
     internal fun attemptUserCreation(
         credential: EmailPasswordCredential
     ): Worker<Result<User, AuthError>> =
-        resultWorker(::AuthError) { authService.createUser(credential) }
+        resultWorker(::AuthError) { userRepository.createUser(credential) }
 }
 
 public sealed interface SignUpOutput {

--- a/core/src/main/kotlin/com/omricat/maplibrarian/auth/SignUpWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/auth/SignUpWorkflow.kt
@@ -62,13 +62,14 @@ internal class ActualSignUpWorkflow(private val userRepository: UserRepository) 
     override fun snapshotState(state: State): Snapshot? = null
 
     private fun handleUserCreationResult(
-        result: Result<User, AuthError>,
+        result: Result<User, UserRepository.Error>,
         credential: EmailPasswordCredential
     ) = result.map { onUserCreated(it) }.getOrElse { e -> onErrorCreatingUser(credential, e) }
 
-    internal fun onErrorCreatingUser(credential: EmailPasswordCredential, e: AuthError) = action {
-        this.state = SignUpPrompt(credential = credential, errorMessage = e.message)
-    }
+    internal fun onErrorCreatingUser(credential: EmailPasswordCredential, e: UserRepository.Error) =
+        action {
+            this.state = SignUpPrompt(credential = credential, errorMessage = e.message)
+        }
 
     internal fun onUserCreated(user: User) = action { setOutput(UserCreated(user)) }
 
@@ -80,8 +81,8 @@ internal class ActualSignUpWorkflow(private val userRepository: UserRepository) 
 
     internal fun attemptUserCreation(
         credential: EmailPasswordCredential
-    ): Worker<Result<User, AuthError>> =
-        resultWorker(::AuthError) { userRepository.createUser(credential) }
+    ): Worker<Result<User, UserRepository.Error>> =
+        resultWorker(::ExceptionWrapperError) { userRepository.createUser(credential) }
 }
 
 public sealed interface SignUpOutput {

--- a/core/src/main/kotlin/com/omricat/maplibrarian/auth/UserRepository.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/auth/UserRepository.kt
@@ -3,13 +3,34 @@ package com.omricat.maplibrarian.auth
 import com.github.michaelbull.result.Result
 import com.omricat.maplibrarian.model.User
 
-public data class AuthError(val message: String) {
+public data class MessageError(override val message: String) : UserRepository.Error {
     public constructor(throwable: Throwable) : this(throwable.message ?: "Unknown error")
 }
 
+public data class ExceptionWrapperError(val throwable: Throwable) : UserRepository.Error {
+    override val message: String
+        get() = throwable.message ?: "No message in $throwable"
+}
+
+public sealed class CreateUserError(override val message: String) : UserRepository.Error {
+    public data class EmailAlreadyInUseError(public val emailAddress: String) :
+        CreateUserError("Email address $emailAddress is already in use")
+
+    public object WeakPasswordError : CreateUserError("Password is too weak")
+    public object UserCreatedButSignedOutError :
+        CreateUserError("User created but needs to sign in again")
+
+    public data class OtherCreateUserError(public override val message: String) :
+        CreateUserError(message)
+}
+
 public interface UserRepository {
-    public suspend fun attemptAuthentication(credential: Credential): Result<User, AuthError>
+    public suspend fun attemptAuthentication(credential: Credential): Result<User, Error>
     public fun signOut()
-    public suspend fun getSignedInUserIfAny(): Result<User?, AuthError>
-    public suspend fun createUser(credential: Credential): Result<User, AuthError>
+    public suspend fun getSignedInUserIfAny(): Result<User?, Error>
+    public suspend fun createUser(credential: Credential): Result<User, CreateUserError>
+
+    public sealed interface Error {
+        public val message: String
+    }
 }

--- a/core/src/main/kotlin/com/omricat/maplibrarian/auth/UserRepository.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/auth/UserRepository.kt
@@ -7,7 +7,7 @@ public data class AuthError(val message: String) {
     public constructor(throwable: Throwable) : this(throwable.message ?: "Unknown error")
 }
 
-public interface AuthService {
+public interface UserRepository {
     public suspend fun attemptAuthentication(credential: Credential): Result<User, AuthError>
     public fun signOut()
     public suspend fun getSignedInUserIfAny(): Result<User?, AuthError>

--- a/core/src/main/kotlin/com/omricat/maplibrarian/root/RootWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/root/RootWorkflow.kt
@@ -3,9 +3,9 @@ package com.omricat.maplibrarian.root
 import com.omricat.maplibrarian.auth.AuthResult
 import com.omricat.maplibrarian.auth.AuthResult.Authenticated
 import com.omricat.maplibrarian.auth.AuthResult.NotAuthenticated
-import com.omricat.maplibrarian.auth.AuthService
 import com.omricat.maplibrarian.auth.AuthWorkflow
 import com.omricat.maplibrarian.auth.AuthorizedScreen
+import com.omricat.maplibrarian.auth.UserRepository
 import com.omricat.maplibrarian.chartlist.ActualChartsWorkflow.Props
 import com.omricat.maplibrarian.chartlist.ChartsWorkflow
 import com.omricat.maplibrarian.model.User
@@ -19,7 +19,7 @@ import com.squareup.workflow1.action
 import com.squareup.workflow1.renderChild
 
 public class RootWorkflow(
-    private val authService: AuthService,
+    private val userRepository: UserRepository,
     private val authWorkflow: AuthWorkflow,
     private val chartsWorkflow: ChartsWorkflow
 ) : StatefulWorkflow<Unit, State, Nothing, Screen>() {
@@ -52,7 +52,7 @@ public class RootWorkflow(
     }
 
     private fun unauthorized() = action {
-        authService.signOut()
+        userRepository.signOut()
         state = Unauthorized
     }
 

--- a/core/src/test/kotlin/com/omricat/maplibrarian/auth/ActualAuthWorkflowTest.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/auth/ActualAuthWorkflowTest.kt
@@ -19,7 +19,7 @@ public class ActualAuthWorkflowTest :
             val fakeCredential = EmailPasswordCredential("a@b.com", "12345")
             val (newState, maybeOutput) =
                 workflow
-                    .onAuthError(AuthError("Authentication failure"))
+                    .onAuthError(MessageError("Authentication failure"))
                     .applyTo(props = Unit, state = State.AttemptingAuthorization(fakeCredential))
 
             assertSoftly {

--- a/core/src/test/kotlin/com/omricat/maplibrarian/auth/ActualAuthWorkflowTest.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/auth/ActualAuthWorkflowTest.kt
@@ -15,7 +15,7 @@ import io.kotest.matchers.types.shouldBeTypeOf
 public class ActualAuthWorkflowTest :
     StringSpec({
         "onAuthError action returns to login prompt" {
-            val workflow = ActualAuthWorkflow(TestAuthService(), NullSignupWorkflow)
+            val workflow = ActualAuthWorkflow(TestUserRepository(), NullSignupWorkflow)
             val fakeCredential = EmailPasswordCredential("a@b.com", "12345")
             val (newState, maybeOutput) =
                 workflow
@@ -31,7 +31,7 @@ public class ActualAuthWorkflowTest :
         }
 
         "onNoAuthenticatedUser action transitions to LoginPrompt" {
-            val workflow = ActualAuthWorkflow(TestAuthService(), NullSignupWorkflow)
+            val workflow = ActualAuthWorkflow(TestUserRepository(), NullSignupWorkflow)
             val (newState, maybeOutput) =
                 workflow.onNoAuthenticatedUser.applyTo(
                     props = Unit,
@@ -45,7 +45,7 @@ public class ActualAuthWorkflowTest :
         }
 
         "onAuthenticated action outputs Authenticated(user) from workflow" {
-            val workflow = ActualAuthWorkflow(TestAuthService(), NullSignupWorkflow)
+            val workflow = ActualAuthWorkflow(TestUserRepository(), NullSignupWorkflow)
             val fakeCredential = EmailPasswordCredential("a@b.com", "12345")
             val fakeUser = TestUser("user1", UserUid("1"), "blah@example.com")
             val (_, maybeOutput) =

--- a/core/src/test/kotlin/com/omricat/maplibrarian/auth/ActualSignUpWorkflowTest.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/auth/ActualSignUpWorkflowTest.kt
@@ -38,7 +38,7 @@ internal class ActualSignUpWorkflowTest :
 
                     val (newState, maybeOutput) =
                         workflow
-                            .onErrorCreatingUser(credential, AuthError("Error creating user"))
+                            .onErrorCreatingUser(credential, MessageError("Error creating user"))
                             .applyTo(props = Unit, state = AttemptingUserCreation(credential))
 
                     assertSoftly {

--- a/core/src/test/kotlin/com/omricat/maplibrarian/auth/ActualSignUpWorkflowTest.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/auth/ActualSignUpWorkflowTest.kt
@@ -18,7 +18,7 @@ internal class ActualSignUpWorkflowTest :
         "actions work correctly" should
             {
                 "onSignUpClicked sets correct state and no output" {
-                    val workflow = ActualSignUpWorkflow(TestAuthService())
+                    val workflow = ActualSignUpWorkflow(TestUserRepository())
                     val credential = EmailPasswordCredential("blah@blah", "password")
 
                     val (newState, maybeOutput) =
@@ -33,7 +33,7 @@ internal class ActualSignUpWorkflowTest :
                 }
 
                 "onErrorCreatingUser sets correct state and no output" {
-                    val workflow = ActualSignUpWorkflow(TestAuthService())
+                    val workflow = ActualSignUpWorkflow(TestUserRepository())
                     val credential = EmailPasswordCredential("blah@blah", "password")
 
                     val (newState, maybeOutput) =
@@ -48,7 +48,7 @@ internal class ActualSignUpWorkflowTest :
                 }
 
                 "onUserCreated sets output to created user" {
-                    val workflow = ActualSignUpWorkflow(TestAuthService())
+                    val workflow = ActualSignUpWorkflow(TestUserRepository())
                     val credential = EmailPasswordCredential("blah@blah", "password")
                     val user = TestUser("user1", UserUid("1234"), "blah@example.com")
 
@@ -67,7 +67,7 @@ internal class ActualSignUpWorkflowTest :
                 }
 
                 "onSignUpCancelled sets output to null applied to AttemptingUserCreation state" {
-                    val workflow = ActualSignUpWorkflow(TestAuthService())
+                    val workflow = ActualSignUpWorkflow(TestUserRepository())
                     val credential = EmailPasswordCredential("blah@blah", "password")
 
                     val (_, maybeOutput) =
@@ -82,7 +82,7 @@ internal class ActualSignUpWorkflowTest :
                 }
 
                 "onSignUpCancelled sets output to null applied to SignUpPrompt state" {
-                    val workflow = ActualSignUpWorkflow(TestAuthService())
+                    val workflow = ActualSignUpWorkflow(TestUserRepository())
 
                     val (_, maybeOutput) =
                         workflow.onSignUpCancelled().applyTo(props = Unit, state = SignUpPrompt())
@@ -97,7 +97,7 @@ internal class ActualSignUpWorkflowTest :
         "rendering ActualSignUpWorkflow" should
             {
                 "be cancellable" {
-                    val workflow = ActualSignUpWorkflow(TestAuthService())
+                    val workflow = ActualSignUpWorkflow(TestUserRepository())
                     workflow
                         .testRender(props = Unit)
                         .render { screen ->

--- a/core/src/test/kotlin/com/omricat/maplibrarian/auth/TestUserRepository.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/auth/TestUserRepository.kt
@@ -3,25 +3,28 @@ package com.omricat.maplibrarian.auth
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
+import com.omricat.maplibrarian.auth.CreateUserError.OtherCreateUserError
 import com.omricat.maplibrarian.model.User
 
 internal class TestUserRepository(
-    private val onAttemptAuthentication: (suspend (Credential) -> Result<User, AuthError>)? = null,
+    private val onAttemptAuthentication: (suspend (Credential) -> Result<User, MessageError>)? =
+        null,
     private val onSignOut: (() -> Unit)? = null,
-    private val onGetSignedInUserIfAny: (suspend () -> Result<User, AuthError>)? = null,
-    private val onCreateUser: (suspend (Credential) -> Result<User, AuthError>)? = null
+    private val onGetSignedInUserIfAny: (suspend () -> Result<User, MessageError>)? = null,
+    private val onCreateUser: (suspend (Credential) -> Result<User, CreateUserError>)? = null
 ) : UserRepository {
-    override suspend fun attemptAuthentication(credential: Credential): Result<User, AuthError> =
+    override suspend fun attemptAuthentication(credential: Credential): Result<User, MessageError> =
         onAttemptAuthentication?.invoke(credential)
-            ?: Err(AuthError("Can't sign in with $credential"))
+            ?: Err(MessageError("Can't sign in with $credential"))
 
     override fun signOut() {
         onSignOut?.invoke()
     }
 
-    override suspend fun getSignedInUserIfAny(): Result<User?, AuthError> =
+    override suspend fun getSignedInUserIfAny(): Result<User?, MessageError> =
         onGetSignedInUserIfAny?.invoke() ?: Ok(null)
 
-    override suspend fun createUser(credential: Credential): Result<User, AuthError> =
-        onCreateUser?.invoke(credential) ?: Err(AuthError("Can't create user with $credential"))
+    override suspend fun createUser(credential: Credential): Result<User, CreateUserError> =
+        onCreateUser?.invoke(credential)
+            ?: Err(OtherCreateUserError("Can't create user with $credential"))
 }

--- a/core/src/test/kotlin/com/omricat/maplibrarian/auth/TestUserRepository.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/auth/TestUserRepository.kt
@@ -5,12 +5,12 @@ import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.Result
 import com.omricat.maplibrarian.model.User
 
-internal class TestAuthService(
+internal class TestUserRepository(
     private val onAttemptAuthentication: (suspend (Credential) -> Result<User, AuthError>)? = null,
     private val onSignOut: (() -> Unit)? = null,
     private val onGetSignedInUserIfAny: (suspend () -> Result<User, AuthError>)? = null,
     private val onCreateUser: (suspend (Credential) -> Result<User, AuthError>)? = null
-) : AuthService {
+) : UserRepository {
     override suspend fun attemptAuthentication(credential: Credential): Result<User, AuthError> =
         onAttemptAuthentication?.invoke(credential)
             ?: Err(AuthError("Can't sign in with $credential"))

--- a/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/FirebaseEndToEndTest.kt
+++ b/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/FirebaseEndToEndTest.kt
@@ -7,7 +7,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.omricat.maplibrarian.auth.EmailPasswordCredential
 import com.omricat.maplibrarian.chartlist.FirebaseChartsService
 import com.omricat.maplibrarian.firebase.auth.FirebaseAuthEmulatorRestApi
-import com.omricat.maplibrarian.firebase.auth.FirebaseAuthService
+import com.omricat.maplibrarian.firebase.auth.FirebaseUserRepository
 import com.omricat.maplibrarian.firebase.charts.FirebaseFirestoreRestApi
 import com.omricat.maplibrarian.model.DbChartModel
 import com.omricat.maplibrarian.model.UnsavedChartModel
@@ -32,7 +32,7 @@ class FirebaseEndToEndTest {
     @Test
     fun addUser_addCharts_queryCharts() = runTest {
         val testDispatcherProvider = TestDispatcherProvider(testScheduler)
-        val userRepository = FirebaseAuthService(firebaseAuthInstance, testDispatcherProvider)
+        val userRepository = FirebaseUserRepository(firebaseAuthInstance, testDispatcherProvider)
 
         val chartsRepository = FirebaseChartsService(firestoreInstance, testDispatcherProvider)
 

--- a/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/FirebaseEndToEndTest.kt
+++ b/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/FirebaseEndToEndTest.kt
@@ -5,9 +5,9 @@ import com.github.michaelbull.result.getOrThrow
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
 import com.omricat.maplibrarian.auth.EmailPasswordCredential
+import com.omricat.maplibrarian.auth.FirebaseUserRepository
 import com.omricat.maplibrarian.chartlist.FirebaseChartsService
 import com.omricat.maplibrarian.firebase.auth.FirebaseAuthEmulatorRestApi
-import com.omricat.maplibrarian.firebase.auth.FirebaseUserRepository
 import com.omricat.maplibrarian.firebase.charts.FirebaseFirestoreRestApi
 import com.omricat.maplibrarian.model.DbChartModel
 import com.omricat.maplibrarian.model.UnsavedChartModel

--- a/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/auth/FirebaseUserRepositoryTest.kt
+++ b/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/auth/FirebaseUserRepositoryTest.kt
@@ -5,6 +5,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.prop
 import com.google.firebase.auth.FirebaseAuth
 import com.omricat.maplibrarian.auth.EmailPasswordCredential
+import com.omricat.maplibrarian.auth.FirebaseUserRepository
 import com.omricat.maplibrarian.firebase.FirebaseEmulatorConnection
 import com.omricat.maplibrarian.firebase.TestDispatcherProvider
 import com.omricat.maplibrarian.firebase.TestFixtures

--- a/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/auth/FirebaseUserRepositoryTest.kt
+++ b/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/auth/FirebaseUserRepositoryTest.kt
@@ -1,15 +1,19 @@
 package com.omricat.maplibrarian.firebase.auth
 
+import assertk.assertAll
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
 import com.google.firebase.auth.FirebaseAuth
+import com.omricat.maplibrarian.auth.CreateUserError
 import com.omricat.maplibrarian.auth.EmailPasswordCredential
 import com.omricat.maplibrarian.auth.FirebaseUserRepository
 import com.omricat.maplibrarian.firebase.FirebaseEmulatorConnection
 import com.omricat.maplibrarian.firebase.TestDispatcherProvider
 import com.omricat.maplibrarian.firebase.TestFixtures
 import com.omricat.maplibrarian.firebase.auth.FirebaseAuthEmulatorRestApi.TestUser
+import com.omricat.result.kotest.assertk.isErr
 import com.omricat.result.kotest.assertk.isOk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -27,14 +31,41 @@ class FirebaseUserRepositoryTest {
 
     private val testCredential = EmailPasswordCredential("test@example.com", "password")
 
-    @Test
-    fun addUserSucceeds() = runTest {
-        val repository =
-            FirebaseUserRepository(firebaseAuthInstance, TestDispatcherProvider(testScheduler))
-        val createUserResult = repository.createUser(testCredential)
-        assertThat(createUserResult).isOk()
-    }
+    class CreateUserTest {
+        @Test
+        fun addUserSucceeds() = runTest {
+            val repository =
+                FirebaseUserRepository(firebaseAuthInstance, TestDispatcherProvider(testScheduler))
+            val createUserResult =
+                repository.createUser(EmailPasswordCredential("test@example.com", "password"))
+            assertThat(createUserResult).isOk()
+        }
 
+        @Test
+        fun tooShortPasswordGivesError() = runTest {
+            val repository =
+                FirebaseUserRepository(firebaseAuthInstance, TestDispatcherProvider(testScheduler))
+            val createUserResult =
+                repository.createUser(EmailPasswordCredential("test@example.com", "pw"))
+            assertThat(createUserResult).isErr().isInstanceOf<CreateUserError.WeakPasswordError>()
+        }
+
+        @Test
+        fun emailCollisionGivesError() = runTest {
+            val repository =
+                FirebaseUserRepository(firebaseAuthInstance, TestDispatcherProvider(testScheduler))
+            val firstCreateUserResult =
+                repository.createUser(EmailPasswordCredential("test@example.com", "password"))
+            val secondCreateUserResult =
+                repository.createUser(EmailPasswordCredential("test@example.com", "password"))
+            assertAll {
+                assertThat(firstCreateUserResult).isOk()
+                assertThat(secondCreateUserResult)
+                    .isErr()
+                    .isInstanceOf<CreateUserError.EmailAlreadyInUseError>()
+            }
+        }
+    }
     @Test
     fun canSignInAddedUser() = runTest {
         val repository =

--- a/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/auth/FirebaseUserRepositoryTest.kt
+++ b/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/auth/FirebaseUserRepositoryTest.kt
@@ -17,7 +17,7 @@ import org.junit.BeforeClass
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class FirebaseAuthServiceTest {
+class FirebaseUserRepositoryTest {
 
     @Before
     fun clearUsers() {
@@ -29,7 +29,7 @@ class FirebaseAuthServiceTest {
     @Test
     fun addUserSucceeds() = runTest {
         val repository =
-            FirebaseAuthService(firebaseAuthInstance, TestDispatcherProvider(testScheduler))
+            FirebaseUserRepository(firebaseAuthInstance, TestDispatcherProvider(testScheduler))
         val createUserResult = repository.createUser(testCredential)
         assertThat(createUserResult).isOk()
     }
@@ -37,7 +37,7 @@ class FirebaseAuthServiceTest {
     @Test
     fun canSignInAddedUser() = runTest {
         val repository =
-            FirebaseAuthService(firebaseAuthInstance, TestDispatcherProvider(testScheduler))
+            FirebaseUserRepository(firebaseAuthInstance, TestDispatcherProvider(testScheduler))
         val createUserResult = repository.createUser(testCredential)
         repository.signOut()
         val signInResult = repository.attemptAuthentication(testCredential)
@@ -48,7 +48,7 @@ class FirebaseAuthServiceTest {
     fun canSignInExternallyAddedUser() = runTest {
         val createdUser = Fixtures.createUserViaRestApi(testCredential)
         val repository =
-            FirebaseAuthService(firebaseAuthInstance, TestDispatcherProvider(testScheduler))
+            FirebaseUserRepository(firebaseAuthInstance, TestDispatcherProvider(testScheduler))
         val signInResult = repository.attemptAuthentication(testCredential)
         assertThat(signInResult)
             .isOk()


### PR DESCRIPTION
- refactor: Rename AuthService to UserRepository
- feat: Map FireBaseAuthException to custom errors
- test: Integration tests for CreateUserError
