### PR TITLE
Imrprove Firestore integration error handling

### DIFF
--- a/.github/workflows/data-integration-tests.yml
+++ b/.github/workflows/data-integration-tests.yml
@@ -112,7 +112,7 @@ jobs:
             adb uninstall "com.omricat.maplibrarian.integrationtesting.debug" || true
             adb uninstall "com.omricat.maplibrarian.debug" || true
             ./gradlew installDebug
-            ./scripts/capture-logcat-logs.sh adb shell am instrument -w com.omricat.maplibrarian.integrationtesting.debug/androidx.test.runner.AndroidJUnitRunner
+            ./scripts/capture-logcat-logs.sh ./scripts/run-instrumented-integration-tests.sh
 
       - name: Extract logs from firebase emulator container
         if: ${{ always() }}

--- a/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
@@ -39,7 +39,6 @@ import com.omricat.maplibrarian.utils.DispatcherProvider
 import com.omricat.maplibrarian.utils.logAndMapException
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 
 class FirebaseChartsRepository(
     private val db: FirebaseFirestore,
@@ -92,9 +91,7 @@ class FirebaseChartsRepository(
                     else -> OtherException(exception)
                 }
             }
-            .onFailure {
-                Timber.w("${FirebaseChartsRepository::class.simpleName} : $it : ${it.message}")
-            }
+            .onFailure { log(Warn) { "error Adding New Chart: ${it.message}" } }
             .map { ref -> newChart.withChartId(ChartId(ref.id)) }
     }
 

--- a/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
@@ -99,7 +99,6 @@ class FirebaseChartsRepository(
         collection("users").document(user.id.value).collection("maps")
 }
 
-@Suppress("UNCHECKED_CAST")
 private fun UnsavedChartModel.withChartId(chartId: ChartId): DbChartModel =
     DbChartModel(userId = userId, title = title, chartId = chartId)
 

--- a/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
@@ -10,11 +10,25 @@ import com.github.michaelbull.result.onFailure
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.FirebaseFirestoreException
+import com.google.firebase.firestore.FirebaseFirestoreException.Code.ALREADY_EXISTS
+import com.google.firebase.firestore.FirebaseFirestoreException.Code.CANCELLED
+import com.google.firebase.firestore.FirebaseFirestoreException.Code.DATA_LOSS
+import com.google.firebase.firestore.FirebaseFirestoreException.Code.INTERNAL
+import com.google.firebase.firestore.FirebaseFirestoreException.Code.OK
+import com.google.firebase.firestore.FirebaseFirestoreException.Code.UNAVAILABLE
+import com.google.firebase.firestore.FirebaseFirestoreException.Code.UNKNOWN
 import com.google.firebase.firestore.QuerySnapshot
 import com.omricat.firebase.interop.runCatchingFirebaseException
 import com.omricat.logging.Loggable
 import com.omricat.logging.Logger
 import com.omricat.logging.log
+import com.omricat.maplibrarian.chartlist.ChartsRepository.AddNewChartError
+import com.omricat.maplibrarian.chartlist.ChartsRepository.AddNewChartError.Cancelled
+import com.omricat.maplibrarian.chartlist.ChartsRepository.AddNewChartError.ChartExists
+import com.omricat.maplibrarian.chartlist.ChartsRepository.AddNewChartError.OtherException
+import com.omricat.maplibrarian.chartlist.ChartsRepository.AddNewChartError.Unavailable
+import com.omricat.maplibrarian.chartlist.ChartsRepository.Error.ExceptionWrappingError
+import com.omricat.maplibrarian.chartlist.ChartsRepository.Error.MessageError
 import com.omricat.maplibrarian.model.ChartId
 import com.omricat.maplibrarian.model.DbChartModel
 import com.omricat.maplibrarian.model.DbChartModelFromMapDeserializer
@@ -22,16 +36,16 @@ import com.omricat.maplibrarian.model.UnsavedChartModel
 import com.omricat.maplibrarian.model.User
 import com.omricat.maplibrarian.model.serializedToMap
 import com.omricat.maplibrarian.utils.DispatcherProvider
-import com.omricat.maplibrarian.utils.logErrorAndMap
+import com.omricat.maplibrarian.utils.logExceptionAndMap
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
+import timber.log.Timber
 
 class FirebaseChartsRepository(
     private val db: FirebaseFirestore,
     private val dispatchers: DispatcherProvider = DispatcherProvider.Default,
     override val logger: Logger
 ) : ChartsRepository, Loggable {
-
     override suspend fun chartsListForUser(
         user: User
     ): Result<List<DbChartModel>, ChartsRepository.Error> =
@@ -40,19 +54,19 @@ class FirebaseChartsRepository(
                     db.mapsCollection(user).get().await()
                 }
             }
-            .mapError(ChartsServiceError::fromThrowable)
-            .onFailure { log(Warn) { "$it" } }
+            .onFailure { log(Warn, throwable = it) }
+            .mapError(::ExceptionWrappingError)
             .andThen { snapshot ->
                 snapshot
                     .map { m -> m.parseMapModel() }
                     .combine()
-                    .mapError { e -> ChartsServiceError(e.message) }
+                    .mapError { e -> MessageError(e.message) }
             }
 
     override suspend fun addNewChart(
         user: User,
         newChart: UnsavedChartModel
-    ): Result<DbChartModel, ChartsRepository.Error> {
+    ): Result<DbChartModel, AddNewChartError> {
         require(user.id == newChart.userId) {
             "UserId of newMap (was ${newChart.userId}) must be " +
                 "same as userId of user (was ${user.id})"
@@ -62,7 +76,25 @@ class FirebaseChartsRepository(
                     db.mapsCollection(user).add(newChart.serializedToMap()).await()
                 }
             }
-            .logErrorAndMap(ChartsServiceError::fromThrowable)
+            .logExceptionAndMap { exception ->
+                when (exception.code) {
+                    UNAVAILABLE -> Unavailable
+                    ALREADY_EXISTS -> ChartExists(newChart)
+                    CANCELLED -> Cancelled
+                    INTERNAL -> error("Firebase threw an internal error. This is unrecoverable.")
+                    DATA_LOSS -> error("Firebase indicated unrecoverable data loss or corruption")
+                    OK ->
+                        error(
+                            "FirebaseFirestoreException $exception had a status code of OK. " +
+                                "Docs say this should never happen."
+                        )
+                    UNKNOWN -> OtherException(exception)
+                    else -> OtherException(exception)
+                }
+            }
+            .onFailure {
+                Timber.w("${FirebaseChartsRepository::class.simpleName} : $it : ${it.message}")
+            }
             .map { ref -> newChart.withChartId(ChartId(ref.id)) }
     }
 
@@ -70,13 +102,6 @@ class FirebaseChartsRepository(
         collection("users").document(user.id.value).collection("maps")
 }
 
-/*
-   It is always safe to upcast ChartModel<Nothing?> to ChartModel<ChartId?> since the only
-   possible value for a val of type Nothing? is null.
-
-   It is safe to cast ChartModel<ChartId?> to ChartModel<ChartId> immediately after setting
-   the chartId parameter to a non-null value.
-*/
 @Suppress("UNCHECKED_CAST")
 private fun UnsavedChartModel.withChartId(chartId: ChartId): DbChartModel =
     DbChartModel(userId = userId, title = title, chartId = chartId)

--- a/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
@@ -36,7 +36,7 @@ import com.omricat.maplibrarian.model.UnsavedChartModel
 import com.omricat.maplibrarian.model.User
 import com.omricat.maplibrarian.model.serializedToMap
 import com.omricat.maplibrarian.utils.DispatcherProvider
-import com.omricat.maplibrarian.utils.logExceptionAndMap
+import com.omricat.maplibrarian.utils.logAndMapException
 import kotlinx.coroutines.tasks.await
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -76,7 +76,7 @@ class FirebaseChartsRepository(
                     db.mapsCollection(user).add(newChart.serializedToMap()).await()
                 }
             }
-            .logExceptionAndMap { exception ->
+            .logAndMapException { exception ->
                 when (exception.code) {
                     UNAVAILABLE -> Unavailable
                     ALREADY_EXISTS -> ChartExists(newChart)

--- a/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
@@ -53,8 +53,7 @@ class FirebaseChartsRepository(
                     db.mapsCollection(user).get().await()
                 }
             }
-            .onFailure { log(Warn, throwable = it) }
-            .mapError(::ExceptionWrappingError)
+            .logAndMapException(::ExceptionWrappingError)
             .andThen { snapshot ->
                 snapshot
                     .map { m -> m.parseMapModel() }

--- a/app/src/main/kotlin/com/omricat/maplibrarian/utils/LogErrorAndMap.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/utils/LogErrorAndMap.kt
@@ -9,5 +9,6 @@ import com.omricat.logging.log
 
 context(Loggable)
 
-inline fun <V, E> Result<V, Throwable>.logErrorAndMap(transform: (Throwable) -> E): Result<V, E> =
-    this.onFailure { logger.log(Warn, throwable = it) { "" } }.mapError(transform)
+inline fun <V, E, T : Exception> Result<V, T>.logExceptionAndMap(
+    transform: (T) -> E
+): Result<V, E> = this.onFailure { logger.log(Warn, throwable = it) { "" } }.mapError(transform)

--- a/app/src/main/kotlin/com/omricat/maplibrarian/utils/LogErrorAndMap.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/utils/LogErrorAndMap.kt
@@ -9,6 +9,6 @@ import com.omricat.logging.log
 
 context(Loggable)
 
-inline fun <V, E, T : Exception> Result<V, T>.logExceptionAndMap(
+inline fun <V, E, T : Exception> Result<V, T>.logAndMapException(
     transform: (T) -> E
 ): Result<V, E> = this.onFailure { logger.log(Warn, throwable = it) { "" } }.mapError(transform)

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/AddNewChartWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/AddNewChartWorkflow.kt
@@ -9,6 +9,7 @@ import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.Event.Saved
 import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.State
 import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.State.Editing
 import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.State.Saving
+import com.omricat.maplibrarian.chartlist.ChartsRepository.AddNewChartError
 import com.omricat.maplibrarian.model.ChartModel
 import com.omricat.maplibrarian.model.DbChartModel
 import com.omricat.maplibrarian.model.UnsavedChartModel
@@ -77,17 +78,18 @@ public class AddNewChartWorkflow(private val chartsRepository: ChartsRepository)
 
     override fun snapshotState(state: State): Snapshot = state.toSnapshot()
 
-    internal fun onErrorSaving(chart: UnsavedChartModel, e: ChartsRepository.Error) = action {
-        state = Editing(chart, errorMessage = e.message)
-    }
+    internal fun onErrorSaving(chart: UnsavedChartModel, e: ChartsRepository.AddNewChartError) =
+        action {
+            state = Editing(chart, errorMessage = e.message)
+        }
 
     internal fun onNewItemSaved(savedChart: DbChartModel) = action { setOutput(Saved) }
 
     private fun saveNewItem(
         user: User,
         chart: UnsavedChartModel
-    ): Worker<Result<DbChartModel, ChartsRepository.Error>> =
-        resultWorker(ChartsServiceError::fromThrowable) {
+    ): Worker<Result<DbChartModel, ChartsRepository.AddNewChartError>> =
+        resultWorker({ e -> AddNewChartError.OtherException(e) }) {
             chartsRepository.addNewChart(user, chart)
         }
 

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsRepository.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsRepository.kt
@@ -30,7 +30,7 @@ public interface ChartsRepository {
 
         public object Cancelled : AddNewChartError("Operation ")
         public data class ChartExists(public val unsavedChartModel: UnsavedChartModel) :
-            AddNewChartError("Chart already exists")
+            AddNewChartError("Chart already exists: $unsavedChartModel")
         public data class OtherException(val exception: Throwable) :
             AddNewChartError(exception.message ?: "No message in $exception")
     }

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsRepository.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsRepository.kt
@@ -14,6 +14,7 @@ public interface ChartsRepository {
         user: User,
         newChart: UnsavedChartModel
     ): Result<DbChartModel, AddNewChartError>
+
     public interface Error {
         public val message: String
 
@@ -29,8 +30,10 @@ public interface ChartsRepository {
         public data object Unavailable : AddNewChartError("Service temporarily unavailable")
 
         public data object Cancelled : AddNewChartError("Operation ")
+
         public data class ChartExists(public val unsavedChartModel: UnsavedChartModel) :
             AddNewChartError("Chart already exists: $unsavedChartModel")
+
         public data class OtherException(val exception: Throwable) :
             AddNewChartError(exception.message ?: "No message in $exception")
     }

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsRepository.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsRepository.kt
@@ -4,7 +4,6 @@ import com.github.michaelbull.result.Result
 import com.omricat.maplibrarian.model.DbChartModel
 import com.omricat.maplibrarian.model.UnsavedChartModel
 import com.omricat.maplibrarian.model.User
-import kotlinx.serialization.Serializable
 
 public interface ChartsRepository {
     public suspend fun chartsListForUser(
@@ -14,20 +13,25 @@ public interface ChartsRepository {
     public suspend fun addNewChart(
         user: User,
         newChart: UnsavedChartModel
-    ): Result<DbChartModel, ChartsRepository.Error>
-
-    public sealed interface Error {
+    ): Result<DbChartModel, AddNewChartError>
+    public interface Error {
         public val message: String
+
+        public data class MessageError(override val message: String) : Error
+
+        public data class ExceptionWrappingError(public val exception: Throwable) : Error {
+            override val message: String
+                get() = exception.message ?: "No message in exception $exception"
+        }
     }
-}
 
-// public typealias ChartsServiceError = ChartsService.Error
-@Serializable
-public data class ChartsServiceError(override val message: String) : ChartsRepository.Error {
-    private constructor(throwable: Throwable) : this(throwable.message ?: "Unknown error")
+    public sealed class AddNewChartError(public val message: String) {
+        public object Unavailable : AddNewChartError("Service temporarily unavailable")
 
-    public companion object {
-        public fun fromThrowable(throwable: Throwable): ChartsServiceError =
-            ChartsServiceError(throwable)
+        public object Cancelled : AddNewChartError("Operation ")
+        public data class ChartExists(public val unsavedChartModel: UnsavedChartModel) :
+            AddNewChartError("Chart already exists")
+        public data class OtherException(val exception: Throwable) :
+            AddNewChartError(exception.message ?: "No message in $exception")
     }
 }

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsRepository.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsRepository.kt
@@ -26,9 +26,9 @@ public interface ChartsRepository {
     }
 
     public sealed class AddNewChartError(public val message: String) {
-        public object Unavailable : AddNewChartError("Service temporarily unavailable")
+        public data object Unavailable : AddNewChartError("Service temporarily unavailable")
 
-        public object Cancelled : AddNewChartError("Operation ")
+        public data object Cancelled : AddNewChartError("Operation ")
         public data class ChartExists(public val unsavedChartModel: UnsavedChartModel) :
             AddNewChartError("Chart already exists: $unsavedChartModel")
         public data class OtherException(val exception: Throwable) :

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflow.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.getOrElse
 import com.github.michaelbull.result.map
 import com.omricat.maplibrarian.chartlist.ActualChartsWorkflow.Props
 import com.omricat.maplibrarian.chartlist.ChartsListWorkflow.Event.SelectItem
+import com.omricat.maplibrarian.chartlist.ChartsRepository.Error.ExceptionWrappingError
 import com.omricat.maplibrarian.chartlist.ChartsScreen.Loading
 import com.omricat.maplibrarian.chartlist.ChartsScreen.ShowError
 import com.omricat.maplibrarian.chartlist.ChartsWorkflowState.AddingItem
@@ -85,9 +86,7 @@ public class ActualChartsWorkflow(
             chartsRepository: ChartsRepository,
             user: User
         ): Worker<Result<List<DbChartModel>, ChartsRepository.Error>> =
-            resultWorker(ChartsServiceError::fromThrowable) {
-                chartsRepository.chartsListForUser(user)
-            }
+            resultWorker(::ExceptionWrappingError) { chartsRepository.chartsListForUser(user) }
     }
 }
 

--- a/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflowTest.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflowTest.kt
@@ -33,7 +33,9 @@ internal class ChartsWorkflowTest :
 
                 "transform ErrorLoadingCharts to RequestData" {
                     val state =
-                        ChartsWorkflowState.ErrorLoadingCharts(ChartsServiceError("Error message"))
+                        ChartsWorkflowState.ErrorLoadingCharts(
+                            ChartsRepository.Error.MessageError("Error message")
+                        )
 
                     ChartsWorkflowState.fromSnapshot(state.toSnapshot()) shouldBe
                         ChartsWorkflowState.RequestData

--- a/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/FirebaseEndToEndTest.kt
+++ b/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/FirebaseEndToEndTest.kt
@@ -1,27 +1,25 @@
 package com.omricat.maplibrarian.firebase
 
-import android.annotation.SuppressLint
 import assertk.all
 import assertk.assertThat
 import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import assertk.assertions.prop
 import com.github.michaelbull.result.getOrThrow
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.firestore.FirebaseFirestore
 import com.omricat.logging.test.TestLogger
 import com.omricat.maplibrarian.auth.EmailPasswordCredential
 import com.omricat.maplibrarian.auth.FirebaseUserRepository
 import com.omricat.maplibrarian.chartlist.FirebaseChartsRepository
-import com.omricat.maplibrarian.firebase.auth.FirebaseAuthEmulatorRestApi
-import com.omricat.maplibrarian.firebase.charts.FirebaseFirestoreRestApi
+import com.omricat.maplibrarian.firebase.TestFixtures.authApi
+import com.omricat.maplibrarian.firebase.TestFixtures.firebaseAuthInstance
+import com.omricat.maplibrarian.firebase.TestFixtures.firestoreApi
+import com.omricat.maplibrarian.firebase.TestFixtures.firestoreInstance
 import com.omricat.maplibrarian.model.UnsavedChartModel
 import com.omricat.result.assertk.isOk
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
-import org.junit.BeforeClass
 import org.junit.Test
 
 @Suppress("FunctionName")
@@ -63,51 +61,6 @@ class FirebaseEndToEndTest {
         assertThat(queryChartResult).isOk().all {
             hasSize(1)
             prop("First item title") { it.first().title }.isEqualTo("New map")
-        }
-    }
-
-    companion object Fixtures {
-
-        // Not a problem to leak a Context in an instrumented test
-        @SuppressLint("StaticFieldLeak")
-        @JvmStatic
-        lateinit var firestoreInstance: FirebaseFirestore
-
-        @JvmStatic lateinit var firestoreApi: FirebaseFirestoreRestApi
-
-        @JvmStatic lateinit var firebaseAuthInstance: FirebaseAuth
-
-        @JvmStatic lateinit var authApi: FirebaseAuthEmulatorRestApi
-
-        @JvmStatic
-        @BeforeClass
-        fun setup() {
-            firestoreInstance =
-                FirebaseFirestore.getInstance(TestFixtures.app).apply {
-                    useEmulator(
-                        FirebaseEmulatorConnection.HOST,
-                        FirebaseEmulatorConnection.FIRESTORE_PORT
-                    )
-                }
-
-            firestoreApi =
-                FirebaseFirestoreRestApi(
-                    TestFixtures.projectId,
-                    TestFixtures.emulatorBaseUrl(FirebaseEmulatorConnection.FIRESTORE_PORT)
-                )
-
-            firebaseAuthInstance =
-                FirebaseAuth.getInstance(TestFixtures.app).apply {
-                    useEmulator(
-                        FirebaseEmulatorConnection.HOST,
-                        FirebaseEmulatorConnection.AUTH_PORT
-                    )
-                }
-            authApi =
-                FirebaseAuthEmulatorRestApi(
-                    TestFixtures.projectId,
-                    TestFixtures.emulatorBaseUrl(FirebaseEmulatorConnection.AUTH_PORT)
-                )
         }
     }
 }

--- a/scripts/run-instrumented-integration-tests.sh
+++ b/scripts/run-instrumented-integration-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -o errexit -o nounset
+adb shell am instrument -w com.omricat.maplibrarian.integrationtesting.debug/androidx.test.runner.AndroidJUnitRunner

--- a/util/logging/src/main/kotlin/com/omricat/logging/Loggable.kt
+++ b/util/logging/src/main/kotlin/com/omricat/logging/Loggable.kt
@@ -25,7 +25,7 @@ public inline fun <reified T : Any> T.log(
     priority: Severity = Debug,
     tag: String? = null,
     throwable: Throwable,
-    noinline message: () -> String
+    noinline message: () -> String = { throwable.message ?: "$throwable" }
 ) {
     logger.log(priority, Tag(tag ?: T::class.outerClassSimpleName()), throwable, message)
 }


### PR DESCRIPTION
- feat: Improve error handling in ChartsRepository
- refactor: Add default message for logging Throwable
- refactor(data): Rename utility function
- feat: Replace Timber with Loggable in ChartsRepo
- feat: Include unsaved chart in error message
- style: Remove unused cast suppression
- refactor: Use data objects in UserRepository errors
- refactor: use utility function in FirebaseChartsRepo
- refactor(test): Centralize integration test fixtures
- test: Make integration tests easy to run
