### PR TITLE
test: Make UserRepository integration tests run

### DIFF
--- a/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/auth/FirebaseUserRepositoryTest.kt
+++ b/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/auth/FirebaseUserRepositoryTest.kt
@@ -17,10 +17,7 @@ import com.omricat.result.assertk.isOk
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
-import org.junit.experimental.runners.Enclosed
-import org.junit.runner.RunWith
 
-@RunWith(Enclosed::class)
 class FirebaseUserRepositoryTest {
 
     @Before


### PR DESCRIPTION
These tests weren't running due to the unnecessary annotation on the
class. Whoops!.
