### PR TITLE
refactor: Remove userId property from ChartModel

### DIFF
--- a/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartModelMapSerialization.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/ChartModelMapSerialization.kt
@@ -3,34 +3,31 @@ package com.omricat.maplibrarian.chartlist
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.binding
 import com.github.michaelbull.result.flatMap
-import com.github.michaelbull.result.map
 import com.github.michaelbull.result.toResultOr
 import com.omricat.maplibrarian.chartlist.DeserializerError.CastError
 import com.omricat.maplibrarian.chartlist.DeserializerError.PropertyNonFoundError
 import com.omricat.maplibrarian.chartlist.MapModelProperties.TITLE
-import com.omricat.maplibrarian.chartlist.MapModelProperties.USER_ID
 import com.omricat.maplibrarian.model.ChartModel
 import com.omricat.maplibrarian.model.UnsavedChartModel
-import com.omricat.maplibrarian.model.UserUid as UserId
 import kotlin.reflect.KClass
 
 private object MapModelProperties {
 
     const val TITLE = "title"
-    const val USER_ID = "userId"
 }
 
 public object ChartModelToMapSerializer {
     fun serializeToMap(model: ChartModel): Map<String, String> =
-        hashMapOf(TITLE to model.title, USER_ID to model.userId.value)
+        hashMapOf(
+            TITLE to model.title,
+        )
 }
 
 public object ChartModelFromMapDeserializer {
     fun deserializeFromMap(properties: Map<String, Any?>): Result<ChartModel, DeserializerError> =
         binding {
-            val userId = properties.getProperty<String>(USER_ID).map { UserId(it) }.bind()
             val title = properties.getProperty<String>(TITLE).bind()
-            UnsavedChartModel(userId = userId, title = title)
+            UnsavedChartModel(title = title)
         }
 }
 

--- a/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
+++ b/app/src/main/kotlin/com/omricat/maplibrarian/chartlist/FirebaseChartsRepository.kt
@@ -64,10 +64,6 @@ class FirebaseChartsRepository(
         user: User,
         newChart: UnsavedChartModel
     ): Result<DbChartModel, AddNewChartError> {
-        require(user.id == newChart.userId) {
-            "UserId of newMap (was ${newChart.userId}) must be " +
-                "same as userId of user (was ${user.id})"
-        }
         return withContext(dispatchers.io) {
                 runCatchingFirestoreException {
                     db.mapsCollection(user)
@@ -100,7 +96,7 @@ class FirebaseChartsRepository(
 }
 
 private fun ChartModel.withChartId(chartId: ChartId): DbChartModel =
-    DbChartModel(userId = userId, title = title, chartId = chartId)
+    DbChartModel(title = title, chartId = chartId)
 
 internal fun DocumentSnapshot.parseMapModel() =
     ChartModelFromMapDeserializer.deserializeFromMap(data ?: emptyMap()).map {

--- a/app/src/test/kotlin/com/omricat/maplibrarian/chartlist/ChartModelSerializationTest.kt
+++ b/app/src/test/kotlin/com/omricat/maplibrarian/chartlist/ChartModelSerializationTest.kt
@@ -6,7 +6,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import com.omricat.maplibrarian.chartlist.DeserializerError.PropertyNonFoundError
 import com.omricat.maplibrarian.model.UnsavedChartModel
-import com.omricat.maplibrarian.model.UserUid
 import com.omricat.result.assertk.isErr
 import com.omricat.result.assertk.isOk
 import kotlin.test.Test
@@ -15,7 +14,7 @@ internal class ChartModelSerializationTest {
 
     @Test
     fun `serializing then deserializing should be identity`() {
-        val chartModel = UnsavedChartModel(UserUid("userId"), "Chart title")
+        val chartModel = UnsavedChartModel("Chart title")
         val result =
             ChartModelFromMapDeserializer.deserializeFromMap(
                 ChartModelToMapSerializer.serializeToMap(chartModel)
@@ -26,10 +25,7 @@ internal class ChartModelSerializationTest {
     @Test
     fun `deserializing should fail if any property is missing`() {
         val serialized: Map<String, Any> =
-            ChartModelToMapSerializer.serializeToMap(
-                UnsavedChartModel(UserUid("userId"), "Chart title")
-            )
-        val id = "map1"
+            ChartModelToMapSerializer.serializeToMap(UnsavedChartModel("Chart title"))
 
         val deserializer = ChartModelFromMapDeserializer
 

--- a/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/AddNewChartWorkflow.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/chartlist/AddNewChartWorkflow.kt
@@ -66,7 +66,7 @@ private class AddNewChartWorkflowImpl(
     private val snapshotter = State.snapshotter(stringFormat)
 
     override fun initialState(props: User, snapshot: Snapshot?): State =
-        snapshot?.let(snapshotter::valueFromSnapshot) ?: Editing(UnsavedChartModel(props.id, ""))
+        snapshot?.let(snapshotter::valueFromSnapshot) ?: Editing(UnsavedChartModel(""))
 
     override fun render(
         renderProps: User,

--- a/core/src/main/kotlin/com/omricat/maplibrarian/model/ChartModel.kt
+++ b/core/src/main/kotlin/com/omricat/maplibrarian/model/ChartModel.kt
@@ -3,19 +3,13 @@ package com.omricat.maplibrarian.model
 import kotlinx.serialization.Serializable
 
 public sealed interface ChartModel {
-    public val userId: UserUid
     public val title: String
 }
 
 @Serializable
-public data class DbChartModel(
-    override val userId: UserUid,
-    override val title: String,
-    public val chartId: ChartId
-) : ChartModel
-
-@Serializable
-public data class UnsavedChartModel(override val userId: UserUid, override val title: String) :
+public data class DbChartModel(override val title: String, public val chartId: ChartId) :
     ChartModel
+
+@Serializable public data class UnsavedChartModel(override val title: String) : ChartModel
 
 @Serializable @JvmInline public value class ChartId(public val id: String)

--- a/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/AddNewChartWorkflowTest.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/AddNewChartWorkflowTest.kt
@@ -5,7 +5,6 @@ import assertk.assertions.isEqualTo
 import assertk.tableOf
 import com.omricat.maplibrarian.chartlist.AddNewChartWorkflow.State
 import com.omricat.maplibrarian.model.UnsavedChartModel
-import com.omricat.maplibrarian.model.UserUid
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -13,7 +12,7 @@ import org.junit.jupiter.api.Test
 internal class AddNewChartWorkflowTest {
     @Nested
     inner class StateSnapshotterTest {
-        private val chart = UnsavedChartModel(UserUid("user"), "title")
+        private val chart = UnsavedChartModel("title")
         private val snapshotter = State.snapshotter(Json)
 
         @Test

--- a/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflowTest.kt
+++ b/core/src/test/kotlin/com/omricat/maplibrarian/chartlist/ChartsWorkflowTest.kt
@@ -6,7 +6,6 @@ import assertk.assertions.isInstanceOf
 import assertk.tableOf
 import com.omricat.maplibrarian.model.ChartId
 import com.omricat.maplibrarian.model.DbChartModel
-import com.omricat.maplibrarian.model.UserUid
 import kotlin.test.Test
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Nested
@@ -25,7 +24,7 @@ internal class ChartsWorkflowTest {
                 .row(ChartsWorkflowState.AddingItem)
                 .row(
                     ChartsWorkflowState.ChartsListLoaded(
-                        listOf(DbChartModel(UserUid("user"), "title", ChartId("chart")))
+                        listOf(DbChartModel("title", ChartId("chart")))
                     )
                 )
                 .forAll { state ->

--- a/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/FirebaseEndToEndTest.kt
+++ b/integration-tests/firebase/src/main/kotlin/com/omricat/maplibrarian/firebase/FirebaseEndToEndTest.kt
@@ -51,8 +51,7 @@ class FirebaseEndToEndTest {
 
         val user = createUserResult.getOrThrow { AssertionError(it) }
 
-        val addChartResult =
-            chartsRepository.addNewChart(user, UnsavedChartModel(user.id, "New map"))
+        val addChartResult = chartsRepository.addNewChart(user, UnsavedChartModel("New map"))
 
         assertThat(addChartResult).isOk()
 


### PR DESCRIPTION
It is no longer an inherent property of ChartModel instances.
