### PR TITLE
build: Remove git hooks Gradle plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,7 +24,6 @@ dependencyResolutionManagement {
 
 plugins {
     id("com.gradle.develocity") version "4.3.2"
-    id("org.danilopianini.gradle-pre-commit-git-hooks") version "2.1.11"
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
@@ -33,11 +32,6 @@ develocity {
         termsOfUseUrl = "https://gradle.com/terms-of-service"
         termsOfUseAgree = "yes"
     }
-}
-
-gitHooks {
-    commitMsg { conventionalCommits() }
-    createHooks()
 }
 
 rootProject.name = ("map-librarian")


### PR DESCRIPTION
I no longer think that automatically creating git hooks is a good idea and in any case, using `jj` means that pre-commit hooks don't run and this was only enforcing conventional commits. It would be better to enforce that in CI.